### PR TITLE
uac_registrant: proper handling of 423 with Min-Expires (#3910)

### DIFF
--- a/modules/uac_registrant/doc/uac_registrant_admin.xml
+++ b/modules/uac_registrant/doc/uac_registrant_admin.xml
@@ -557,14 +557,17 @@ modparam("uac_registrant", "reregister_expiry_percentage", 90)
 		When set to <quote>1</quote> (default), such a 423 is treated as a
 		registrar error (the registration enters the registrar-error state and
 		is retried later according to the failure back-off). When set to
-		<quote>0</quote>, the registrant tolerates the non-conformant reply and
-		retries the REGISTER using the advertised Min-Expires value anyway
-		(legacy behavior).
+		<quote>0</quote> (tolerant mode), the registrant tolerates the
+		non-conformant reply and retries the REGISTER using the advertised
+		Min-Expires value anyway.
 		</para>
 		<para>
-		Note that a 423 reply with a missing or unparsable Min-Expires header is
-		always treated as a registrar error, regardless of this parameter, since
-		there is no value to retry with.
+		Note that a 423 reply with a missing or unparsable Min-Expires header,
+		one carrying a value of <quote>0</quote> (retrying with it would send
+		Expires: 0, de-registering the contact), or one demanding an
+		implausibly large minimum (more than one day) is always treated as a
+		registrar error, regardless of this parameter, since there is no usable
+		value to retry with.
 		</para>
 		<para>
 		<emphasis>

--- a/modules/uac_registrant/doc/uac_registrant_admin.xml
+++ b/modules/uac_registrant/doc/uac_registrant_admin.xml
@@ -562,6 +562,12 @@ modparam("uac_registrant", "reregister_expiry_percentage", 90)
 		Min-Expires value anyway.
 		</para>
 		<para>
+		Whenever a 423 is accepted (in either mode), the advertised Min-Expires
+		is adopted as the registrant's requested expiration and reused for every
+		subsequent re-REGISTER. The interval is therefore renegotiated only once,
+		rather than incurring a 423 round-trip on each refresh.
+		</para>
+		<para>
 		Note that a 423 reply with a missing or unparsable Min-Expires header,
 		one carrying a value of <quote>0</quote> (retrying with it would send
 		Expires: 0, de-registering the contact), or one demanding an

--- a/modules/uac_registrant/doc/uac_registrant_admin.xml
+++ b/modules/uac_registrant/doc/uac_registrant_admin.xml
@@ -541,6 +541,46 @@ modparam("uac_registrant", "reregister_expiry_percentage", 90)
 		</example>
 	</section>
 
+	<section id="param_min_expires_strict" xreflabel="min_expires_strict">
+		<title><varname>min_expires_strict</varname> (integer)</title>
+		<para>
+		Controls how a <emphasis>423 (Interval Too Brief)</emphasis> reply is
+		handled when its <emphasis>Min-Expires</emphasis> header carries a value
+		that is <emphasis>not greater</emphasis> than the expiration interval the
+		registrant requested. As per RFC 3261 (sections 10.3 and 10.2.8) a
+		registrar must only reply 423 when the requested expiration is smaller
+		than its configured minimum, so a conformant Min-Expires is always
+		strictly greater than the requested value; a Min-Expires that is not
+		greater is therefore a non-conformant reply.
+		</para>
+		<para>
+		When set to <quote>1</quote> (default), such a 423 is treated as a
+		registrar error (the registration enters the registrar-error state and
+		is retried later according to the failure back-off). When set to
+		<quote>0</quote>, the registrant tolerates the non-conformant reply and
+		retries the REGISTER using the advertised Min-Expires value anyway
+		(legacy behavior).
+		</para>
+		<para>
+		Note that a 423 reply with a missing or unparsable Min-Expires header is
+		always treated as a registrar error, regardless of this parameter, since
+		there is no value to retry with.
+		</para>
+		<para>
+		<emphasis>
+			Default value is <quote>1</quote>.
+		</emphasis>
+		</para>
+		<example>
+		<title>Set <quote>min_expires_strict</quote> parameter</title>
+		<programlisting format="linespecific">
+...
+modparam("uac_registrant", "min_expires_strict", 0)
+...
+</programlisting>
+		</example>
+	</section>
+
 	</section>
 
 	<section id="exported_functions" xreflabel="exported_functions">

--- a/modules/uac_registrant/min_expires.c
+++ b/modules/uac_registrant/min_expires.c
@@ -1,0 +1,38 @@
+/*
+ * Decision logic for handling a 423 (Interval Too Brief) reply.
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+#include "min_expires.h"
+
+/* The truth table and the full rationale for each outcome live with the enum in
+ * min_expires.h; the branches below carry only a one-line tag each. Keep this a
+ * pure function (no logging, no globals) so test/test.c can exercise it as a
+ * standalone translation unit. */
+enum min_expires_action min_expires_decide(unsigned int min_expires,
+		unsigned int wanted_expires, int strict)
+{
+	if (min_expires == 0)                       /* no header, or Expires:0 footgun */
+		return ME_ERR_NO_VALUE;
+	if (min_expires > UAC_REG_MAX_SANE_EXPIRES) /* broken registrar; never ratchet */
+		return ME_ERR_INSANE;
+	if (min_expires > wanted_expires)           /* conformant: strict '>', not '>=' */
+		return ME_RETRY_CONFORMANT;
+	/* 0 < min_expires <= wanted_expires: non-conformant 423 */
+	return strict ? ME_ERR_NONCONFORMANT : ME_RETRY_TOLERATED;
+}

--- a/modules/uac_registrant/min_expires.h
+++ b/modules/uac_registrant/min_expires.h
@@ -1,0 +1,88 @@
+/*
+ * Decision logic for handling a 423 (Interval Too Brief) reply.
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+#ifndef _UAC_REGISTRANT_MIN_EXPIRES_H_
+#define _UAC_REGISTRANT_MIN_EXPIRES_H_
+
+/*
+ * Defensive upper bound on a registrar-advertised Min-Expires we are willing
+ * to adopt. A 423 demanding a *minimum* registration interval longer than this
+ * is treated as a registrar error (ME_ERR_INSANE) rather than retried: no sane
+ * registrar requires it, and adopting it would ratchet our requested expiry up
+ * to a pathological value with no way back down. Clamping below the demanded
+ * minimum is not an option either - it would just earn another 423 and loop.
+ * One day is already far above any realistic minimum expiry.
+ */
+#define UAC_REG_MAX_SANE_EXPIRES 86400
+
+/*
+ * How the registrant should react to a 423 (Interval Too Brief) reply, and why.
+ * This enum is the single source of truth for the decision: min_expires_decide()
+ * picks one value, and the caller maps it straight to a log message and a state
+ * transition without re-deriving any of these conditions.
+ *
+ * Rationale (RFC 3261 10.3 / 10.2.8 and the min_expires_strict modparam):
+ * a registrar may reply 423 only when the requested expiration is *smaller*
+ * than its configured minimum, so a conformant Min-Expires is always strictly
+ * greater than what we requested, and 10.2.8 lets us retry with a value "equal
+ * to or greater than" it (we use exactly it). On any accepted 423 the value is
+ * stored in rec->wanted_expires (what send_register() actually puts on the
+ * wire), so the retry carries it AND every later re-REGISTER reuses it - the
+ * interval is renegotiated once, not on each refresh.
+ *
+ * Truth table (M = Min-Expires from the 423, 0 if no parsable header;
+ *              W = the expiry we requested; strict = min_expires_strict):
+ *
+ *   condition                       strict=1               strict=0
+ *   ------------------------------  ---------------------  -------------------
+ *   M == 0 (or no header)           ME_ERR_NO_VALUE        ME_ERR_NO_VALUE
+ *   M >  UAC_REG_MAX_SANE_EXPIRES    ME_ERR_INSANE          ME_ERR_INSANE
+ *   M >  W   (conformant)           ME_RETRY_CONFORMANT    ME_RETRY_CONFORMANT
+ *   0 < M <= W (non-conformant)     ME_ERR_NONCONFORMANT   ME_RETRY_TOLERATED
+ */
+enum min_expires_action {
+	ME_RETRY_CONFORMANT,  /* Min-Expires > requested: retry (both modes)      */
+	ME_RETRY_TOLERATED,   /* Min-Expires <= requested, strict=0: retry anyway */
+	/* No usable value to retry with (no parsable header, or M == 0). Error in
+	 * both modes: retrying with 0 would put Expires: 0 on the wire - a
+	 * de-registration - while the record still believes it is REGISTERED, so
+	 * tolerant mode must never flip it. */
+	ME_ERR_NO_VALUE,
+	ME_ERR_INSANE,        /* Min-Expires > UAC_REG_MAX_SANE_EXPIRES (see macro) */
+	ME_ERR_NONCONFORMANT, /* Min-Expires <= requested, rejected by strict=1   */
+};
+
+/*
+ * Decide how to handle a 423 reply; see the rationale above for the policy.
+ *
+ *   min_expires    - the Min-Expires value; pass 0 when the 423 carried no
+ *                    parsable Min-Expires header (a missing header and an
+ *                    explicit 0 are indistinguishable here, by design: both
+ *                    mean "no usable value" -> ME_ERR_NO_VALUE)
+ *   wanted_expires - the expiration the registrant requested
+ *   strict         - value of the min_expires_strict modparam (0 or 1)
+ *
+ * Pure function (no side effects, no globals) so it can be unit tested
+ * directly - see test/test.c.
+ */
+enum min_expires_action min_expires_decide(unsigned int min_expires,
+		unsigned int wanted_expires, int strict);
+
+#endif /* _UAC_REGISTRANT_MIN_EXPIRES_H_ */

--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -43,6 +43,7 @@
 #include "reg_db_handler.h"
 #include "clustering.h"
 #include "reg_events.h"
+#include "min_expires.h"
 
 
 #define UAC_REGISTRAR_URI_PARAM              1
@@ -734,59 +735,57 @@ int run_reg_tm_cback(void *e_data, void *data, void *r_data)
 			LM_ERR("FAKED_REPLY\n");
 			goto done;
 		}
-		if (0 == parse_min_expires(msg)) {
-			exp = (unsigned int)(long)msg->min_expires->parsed;
-			/* RFC 3261 10.3: a registrar may only reply 423 when the
-			 * requested expiration is *smaller* than its configured
-			 * minimum, so a conformant Min-Expires is always strictly
-			 * greater than what we requested. RFC 3261 10.2.8 then lets
-			 * us retry with an expiration "equal to or greater than"
-			 * Min-Expires - we use exactly Min-Expires.
-			 *
-			 * The new value is stored in rec->wanted_expires (the value
-			 * actually put on the wire by send_register), so that the
-			 * retry carries it AND the subsequent re-registrations reuse
-			 * it directly, avoiding a 423 round-trip on every refresh.
-			 * Note: updating rec->expires here would have no effect, as
-			 * send_register() sends rec->wanted_expires.
-			 *
-			 * A Min-Expires that is not greater than what we requested is
-			 * a non-conformant 423. By default (min_expires_strict=1) we
-			 * treat it as a registrar error; with min_expires_strict=0 we
-			 * tolerate it and retry with the advertised value anyway. */
-			if (exp > rec->wanted_expires || !min_expires_strict) {
-				if (exp > rec->wanted_expires)
-					LM_DBG("registrar requested Min-Expires=[%u] > requested "
-						"expires=[%u] for AOR=[%.*s], retrying REGISTER\n",
-						exp, rec->wanted_expires,
-						rec->td.rem_uri.len, rec->td.rem_uri.s);
-				else
-					LM_WARN("non-conformant 423 for AOR=[%.*s]: Min-Expires=[%u] "
-						"not greater than requested expires=[%u]; accepting it "
-						"anyway (min_expires_strict=0)\n",
-						rec->td.rem_uri.len, rec->td.rem_uri.s,
-						exp, rec->wanted_expires);
-				rec->wanted_expires = exp;
-				if(send_register(cb_param->hash_index, rec, NULL)==1) {
-					reg_change_state(rec,REGISTERING_STATE);
-				} else {
-					reg_change_state(rec,INTERNAL_ERROR_STATE);
-				}
+		/* exp == 0 means "no usable Min-Expires" (no/unparsable header, or an
+		 * explicit 0); min_expires_decide() treats both the same. On an accepted
+		 * retry we store exp into rec->wanted_expires (the value send_register()
+		 * puts on the wire), so it carries into this retry and every later
+		 * refresh - negotiated once, no 423 round-trip per refresh. Full
+		 * RFC-3261 rationale and the truth table live with enum
+		 * min_expires_action in min_expires.h. */
+		exp = (0 == parse_min_expires(msg)) ?
+			(unsigned int)(long)msg->min_expires->parsed : 0;
+		switch (min_expires_decide(exp, rec->wanted_expires, min_expires_strict)) {
+		case ME_RETRY_CONFORMANT:
+			LM_DBG("registrar requested Min-Expires=[%u] > requested "
+				"expires=[%u] for AOR=[%.*s], retrying REGISTER\n",
+				exp, rec->wanted_expires,
+				rec->td.rem_uri.len, rec->td.rem_uri.s);
+			goto retry_register;
+		case ME_RETRY_TOLERATED:
+			LM_WARN("non-conformant 423 for AOR=[%.*s]: Min-Expires=[%u] "
+				"not greater than requested expires=[%u]; accepting it "
+				"anyway (min_expires_strict=0)\n",
+				rec->td.rem_uri.len, rec->td.rem_uri.s,
+				exp, rec->wanted_expires);
+retry_register:
+			rec->wanted_expires = exp;
+			if(send_register(cb_param->hash_index, rec, NULL)==1) {
+				reg_change_state(rec,REGISTERING_STATE);
 			} else {
-				LM_ERR("bogus 423 reply for AOR=[%.*s]: Min-Expires=[%u] "
-					"not greater than requested expires=[%u] "
-					"(set min_expires_strict=0 to accept it anyway)\n",
-					rec->td.rem_uri.len, rec->td.rem_uri.s,
-					exp, rec->wanted_expires);
-				reg_change_state(rec,REGISTRAR_ERROR_STATE);
-				rec->registration_timeout = now + (failure_retry_interval?failure_retry_interval:(rec->expires*reregister_exp_percentage/100)) - timer_interval;
+				reg_change_state(rec,INTERNAL_ERROR_STATE);
 			}
-		} else {
-			LM_ERR("received 423 reply with no valid Min-Expires header "
+			break;
+		case ME_ERR_NO_VALUE:
+			LM_ERR("received 423 reply with no usable Min-Expires value "
 				"for AOR=[%.*s], treating as registrar error\n",
 				rec->td.rem_uri.len, rec->td.rem_uri.s);
+			goto registrar_error;
+		case ME_ERR_INSANE:
+			LM_ERR("423 reply for AOR=[%.*s] demands Min-Expires=[%u] above "
+				"the sane maximum [%u]; refusing as a registrar error\n",
+				rec->td.rem_uri.len, rec->td.rem_uri.s,
+				exp, (unsigned int)UAC_REG_MAX_SANE_EXPIRES);
+			goto registrar_error;
+		case ME_ERR_NONCONFORMANT:
+			LM_ERR("bogus 423 reply for AOR=[%.*s]: Min-Expires=[%u] "
+				"not greater than requested expires=[%u] "
+				"(set min_expires_strict=0 to accept it anyway)\n",
+				rec->td.rem_uri.len, rec->td.rem_uri.s,
+				exp, rec->wanted_expires);
+registrar_error:
 			reg_change_state(rec,REGISTRAR_ERROR_STATE);
 			rec->registration_timeout = now + (failure_retry_interval?failure_retry_interval:(rec->expires*reregister_exp_percentage/100)) - timer_interval;
+			break;
 		}
 		break;
 

--- a/modules/uac_registrant/registrant.c
+++ b/modules/uac_registrant/registrant.c
@@ -122,6 +122,11 @@ unsigned int default_expires = 3600;
 unsigned int timer_interval = 100;
 unsigned int failure_retry_interval = 0;
 unsigned int reregister_exp_percentage=100;
+/* on a 423 reply whose Min-Expires is not greater than the requested
+ * expires (a non-conformant 423 per RFC 3261 10.3): 1 = treat as a
+ * registrar error (default), 0 = tolerate it and retry with the
+ * advertised Min-Expires (legacy behavior) */
+unsigned int min_expires_strict = 1;
 
 reg_table_t reg_htable = NULL;
 unsigned int reg_hsize = 1;
@@ -170,6 +175,7 @@ static const param_export_t params[]= {
 	{"cluster_shtag_column",	STR_PARAM,	&cluster_shtag_column.s},
 	{"state_column",	STR_PARAM,		&state_column.s},
 	{"reregister_expiry_percentage", INT_PARAM,	&reregister_exp_percentage},
+	{"min_expires_strict",	INT_PARAM,			&min_expires_strict},
 	{0,0,0}
 };
 
@@ -729,13 +735,56 @@ int run_reg_tm_cback(void *e_data, void *data, void *r_data)
 			goto done;
 		}
 		if (0 == parse_min_expires(msg)) {
-			rec->expires = (unsigned int)(long)msg->min_expires->parsed;
-			if(send_register(cb_param->hash_index, rec, NULL)==1) {
-				reg_change_state(rec,REGISTERING_STATE);
+			exp = (unsigned int)(long)msg->min_expires->parsed;
+			/* RFC 3261 10.3: a registrar may only reply 423 when the
+			 * requested expiration is *smaller* than its configured
+			 * minimum, so a conformant Min-Expires is always strictly
+			 * greater than what we requested. RFC 3261 10.2.8 then lets
+			 * us retry with an expiration "equal to or greater than"
+			 * Min-Expires - we use exactly Min-Expires.
+			 *
+			 * The new value is stored in rec->wanted_expires (the value
+			 * actually put on the wire by send_register), so that the
+			 * retry carries it AND the subsequent re-registrations reuse
+			 * it directly, avoiding a 423 round-trip on every refresh.
+			 * Note: updating rec->expires here would have no effect, as
+			 * send_register() sends rec->wanted_expires.
+			 *
+			 * A Min-Expires that is not greater than what we requested is
+			 * a non-conformant 423. By default (min_expires_strict=1) we
+			 * treat it as a registrar error; with min_expires_strict=0 we
+			 * tolerate it and retry with the advertised value anyway. */
+			if (exp > rec->wanted_expires || !min_expires_strict) {
+				if (exp > rec->wanted_expires)
+					LM_DBG("registrar requested Min-Expires=[%u] > requested "
+						"expires=[%u] for AOR=[%.*s], retrying REGISTER\n",
+						exp, rec->wanted_expires,
+						rec->td.rem_uri.len, rec->td.rem_uri.s);
+				else
+					LM_WARN("non-conformant 423 for AOR=[%.*s]: Min-Expires=[%u] "
+						"not greater than requested expires=[%u]; accepting it "
+						"anyway (min_expires_strict=0)\n",
+						rec->td.rem_uri.len, rec->td.rem_uri.s,
+						exp, rec->wanted_expires);
+				rec->wanted_expires = exp;
+				if(send_register(cb_param->hash_index, rec, NULL)==1) {
+					reg_change_state(rec,REGISTERING_STATE);
+				} else {
+					reg_change_state(rec,INTERNAL_ERROR_STATE);
+				}
 			} else {
-				reg_change_state(rec,INTERNAL_ERROR_STATE);
+				LM_ERR("bogus 423 reply for AOR=[%.*s]: Min-Expires=[%u] "
+					"not greater than requested expires=[%u] "
+					"(set min_expires_strict=0 to accept it anyway)\n",
+					rec->td.rem_uri.len, rec->td.rem_uri.s,
+					exp, rec->wanted_expires);
+				reg_change_state(rec,REGISTRAR_ERROR_STATE);
+				rec->registration_timeout = now + (failure_retry_interval?failure_retry_interval:(rec->expires*reregister_exp_percentage/100)) - timer_interval;
 			}
 		} else {
+			LM_ERR("received 423 reply with no valid Min-Expires header "
+				"for AOR=[%.*s], treating as registrar error\n",
+				rec->td.rem_uri.len, rec->td.rem_uri.s);
 			reg_change_state(rec,REGISTRAR_ERROR_STATE);
 			rec->registration_timeout = now + (failure_retry_interval?failure_retry_interval:(rec->expires*reregister_exp_percentage/100)) - timer_interval;
 		}

--- a/modules/uac_registrant/test/opensips.cfg
+++ b/modules/uac_registrant/test/opensips.cfg
@@ -1,0 +1,34 @@
+#
+# Minimal config used by the OpenSIPS unit-test framework to load the
+# uac_registrant module for its TAP tests:
+#
+#     make test module=uac_registrant
+#
+# which runs:  opensips -dd -T uac_registrant -w . -a HP_MALLOC
+#
+# No db_url is set (it is optional - mod_init skips DB support when absent), so
+# the module initialises with an empty registrant set and mod_tests() runs the
+# pure-logic checks in test/test.c.
+#
+
+log_level = 2
+stderror_enabled = yes
+syslog_enabled = no
+
+udp_workers = 1
+auto_aliases = no
+enable_asserts = true
+abort_on_assert = true
+
+socket = udp:localhost:5070
+
+mpath = "modules/"
+
+loadmodule "proto_udp.so"
+loadmodule "tm.so"
+loadmodule "uac_auth.so"
+loadmodule "uac_registrant.so"
+
+route {
+	drop;
+}

--- a/modules/uac_registrant/test/sipp/README.md
+++ b/modules/uac_registrant/test/sipp/README.md
@@ -51,6 +51,24 @@ The runner passes `opensips -i` to skip the module git-revision cross-check,
 which only matters in a local build tree that mixes revisions; version and
 compile-flags are still verified.
 
+## Expected output
+
+On success every case prints `PASS` and the runner exits `0`:
+
+```text
+------------------------------------------------------------
+PASS  A_conformant    sipp=ok  state=REGISTERED_STATE
+PASS  B_low_strict    sipp=ok  state=REGISTRAR_ERROR_STATE
+PASS  C_low_tolerant  sipp=ok  state=REGISTERED_STATE
+PASS  D_missing       sipp=ok  state=REGISTRAR_ERROR_STATE
+PASS  E_equal_strict  sipp=ok  state=REGISTRAR_ERROR_STATE
+------------------------------------------------------------
+result: 5 passed, 0 failed
+```
+
+A failing case instead prints `FAIL` with the offending SIPp verdict and/or MI
+state, and the runner exits non-zero.
+
 ## Files
 
 | File | Purpose |
@@ -68,3 +86,7 @@ TAP unit tests in `../test.c`, run with:
 ```sh
 make test module=uac_registrant
 ```
+
+These pin the full truth table — 20 assertions, including the strict `>`
+boundary, the `Min-Expires: 0` case, and the over-maximum case — and on success
+print `1..20` with every line reported `ok`.

--- a/modules/uac_registrant/test/sipp/README.md
+++ b/modules/uac_registrant/test/sipp/README.md
@@ -1,0 +1,70 @@
+# uac_registrant 423 / Min-Expires integration tests (SIPp)
+
+End-to-end tests for the registrant's handling of a `423 (Interval Too Brief)`
+reply, i.e. the fix in GitHub issue #3910 and the `min_expires_strict` modparam.
+
+A SIPp UAS plays the **registrar** and answers the registrant's `REGISTER` with a
+crafted `423`. A real OpenSIPS instance runs the `uac_registrant` module under
+test; the registrant is injected at runtime over the MI FIFO (`reg_upsert`), so a
+single config drives every case.
+
+## What is asserted
+
+Each case checks two independent things:
+
+1. **On-the-wire behaviour (SIPp).** Positive cases enforce that the retry
+   `REGISTER` carries the expected `;expires=` value using an `ereg`
+   `check_it="true"`; negative cases pass only if **no** retry arrives within the
+   window.
+2. **State-machine outcome (MI).** After the exchange, `reg_list` is queried over
+   the MI FIFO and the registrant's `state` is compared against the expectation
+   (`REGISTERED_STATE` vs `REGISTRAR_ERROR_STATE`).
+
+## Cases
+
+With requested expires `W = 60` and `M` = the `Min-Expires` we send back:
+
+| Case | Reply | `min_expires_strict` | Expected behaviour | Final state |
+|------|-------|----------------------|--------------------|-------------|
+| A | `Min-Expires: 120` (`M > W`, conformant) | 1 | retry with 120, accept | `REGISTERED` |
+| B | `Min-Expires: 30` (`M < W`) | 1 | registrar error, **no retry** | `REGISTRAR_ERROR` |
+| C | `Min-Expires: 30` (`M < W`) | 0 | retry with 30 (legacy/tolerant), accept | `REGISTERED` |
+| D | no `Min-Expires` header | 1 | registrar error, **no retry** | `REGISTRAR_ERROR` |
+| E | `Min-Expires: 60` (`M == W`, boundary) | 1 | registrar error, **no retry** (pins the strict `>`) | `REGISTRAR_ERROR` |
+
+## Running
+
+```sh
+cd modules/uac_registrant/test/sipp
+./run.sh            # run all cases
+./run.sh -v         # keep the per-case work dirs (/tmp/uacreg_sipp.*) for debugging
+./run.sh A_conformant E_equal_strict   # run a subset
+```
+
+Requirements: a built `opensips` in the source root (`make`), `sipp`, `jq`. The
+runner loads the freshly built modules from `../../..//modules/` and listens on
+`udp:127.0.0.1:5060` (OpenSIPS) and `udp:127.0.0.1:5070` (SIPp registrar);
+override with the `OPENSIPS_BIN`, `OPENSIPS_MPATH`, `SIPP_BIN` environment
+variables if needed.
+
+The runner passes `opensips -i` to skip the module git-revision cross-check,
+which only matters in a local build tree that mixes revisions; version and
+compile-flags are still verified.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `run.sh` | orchestrator: per-case OpenSIPS + SIPp lifecycle, MI assertions |
+| `opensips.cfg.template` | config template (placeholders filled in per run) |
+| `db/version`, `db/registrant` | empty `db_text` seed (registrant added via MI) |
+| `scenarios/case_*.xml` | the five SIPp registrar scenarios |
+
+## Related unit tests
+
+The pure decision behind these flows (`min_expires_decide()`) is also covered by
+TAP unit tests in `../test.c`, run with:
+
+```sh
+make test module=uac_registrant
+```

--- a/modules/uac_registrant/test/sipp/README.md
+++ b/modules/uac_registrant/test/sipp/README.md
@@ -81,12 +81,49 @@ state, and the runner exits non-zero.
 ## Related unit tests
 
 The pure decision behind these flows (`min_expires_decide()`) is also covered by
-TAP unit tests in `../test.c`, run with:
+TAP unit tests in `../test.c`. The harness-native way to run them is a clean
+rebuild followed by `make test`, which guarantees every object shares one git
+revision before the assertions run:
 
 ```sh
-make test module=uac_registrant
+make clean all modules && make test module=uac_registrant
 ```
 
-These pin the full truth table — 20 assertions, including the strict `>`
-boundary, the `Min-Expires: 0` case, and the over-maximum case — and on success
-print `1..20` with every line reported `ok`.
+On a local tree that mixes object revisions — typical right after a rebase,
+amend, or branch checkout that leaves some objects built at a different commit —
+you can skip the full rebuild and run the test binary directly. `-i` bypasses the
+module git-revision cross-check (the module version string and compile flags are
+still verified):
+
+```sh
+./opensips -dd -T uac_registrant -w . -a HP_MALLOC -i
+```
+
+(optionally preceded by `make modules modules=modules/uac_registrant` to pick up
+local edits first).
+
+These pin the full truth table — 17 assertions, including the strict `>`
+boundary, the `Min-Expires: 0` case, and the over-maximum case.
+
+**Read the TAP output, not the banner.** Success is the TAP `1..N` plan line —
+here `1..17` — followed by `N` lines that all begin with `ok`, and zero `not ok`
+lines. The `-i` invocation prints exactly that and nothing else:
+
+```text
+ok 15 - zero/missing Min-Expires, tolerant: registrar error (never self-de-register)
+ok 16 - strict flips the non-conformant case
+ok 17 - strict does not affect the conformant case
+1..17
+```
+
+`make test` additionally prints a `Passed All Tests!` banner after the plan line.
+Do **not** treat that banner alone as proof: `Makefile.test` echoes it whenever
+the `opensips` process exits `0`, and the process can exit `0` without ever
+reaching the test runner. The trap is a stale **built-in** module — if a
+`CRITICAL:core:version_control ... revision mismatch` line appears (e.g. for
+`proto_udp` after a rebase), `load_static_module()` calls `exit(0)`
+(`sr_module.c`), so the binary stops before the assertions run yet `make` still
+prints the banner. (A failing assertion, a wrong plan count, or a *dynamically*
+loaded module mismatch each exit non-zero and abort `make` with `Error 1`, so
+those are caught.) If you see that mismatch line, rebuild as above or pass `-i`,
+and confirm the `1..17` plan line is actually present.

--- a/modules/uac_registrant/test/sipp/README.md
+++ b/modules/uac_registrant/test/sipp/README.md
@@ -31,6 +31,16 @@ With requested expires `W = 60` and `M` = the `Min-Expires` we send back:
 | C | `Min-Expires: 30` (`M < W`) | 0 | retry with 30 (legacy/tolerant), accept | `REGISTERED` |
 | D | no `Min-Expires` header | 1 | registrar error, **no retry** | `REGISTRAR_ERROR` |
 | E | `Min-Expires: 60` (`M == W`, boundary) | 1 | registrar error, **no retry** (pins the strict `>`) | `REGISTRAR_ERROR` |
+| F | `Min-Expires: 120` (`M > W`), then a **forced refresh** | 1 | retry with 120, accept; the refresh re-REGISTER **still carries 120** | `REGISTERED` |
+
+Case **F** pins *persistence* — the regression bogdan-iancu described on #3910. The
+#3659 change made the record's `expires` field ephemeral (re-seeded from
+`wanted_expires` each cycle), so the negotiated `Min-Expires` has to be stored in
+the persistent `wanted_expires`; otherwise the immediate retry works but every
+later re-REGISTER reverts to the originally requested value. After the conformant
+423/retry/accept, the harness forces a re-REGISTER and the scenario asserts that
+refresh **also** carries `expires=120`. (A revert to `60` here is invisible to
+cases A–E, which each exercise a single cycle.)
 
 ## Running
 
@@ -62,8 +72,9 @@ PASS  B_low_strict    sipp=ok  state=REGISTRAR_ERROR_STATE
 PASS  C_low_tolerant  sipp=ok  state=REGISTERED_STATE
 PASS  D_missing       sipp=ok  state=REGISTRAR_ERROR_STATE
 PASS  E_equal_strict  sipp=ok  state=REGISTRAR_ERROR_STATE
+PASS  F_persist       sipp=ok  state=REGISTERED_STATE
 ------------------------------------------------------------
-result: 5 passed, 0 failed
+result: 6 passed, 0 failed
 ```
 
 A failing case instead prints `FAIL` with the offending SIPp verdict and/or MI
@@ -76,7 +87,7 @@ state, and the runner exits non-zero.
 | `run.sh` | orchestrator: per-case OpenSIPS + SIPp lifecycle, MI assertions |
 | `opensips.cfg.template` | config template (placeholders filled in per run) |
 | `db/version`, `db/registrant` | empty `db_text` seed (registrant added via MI) |
-| `scenarios/case_*.xml` | the five SIPp registrar scenarios |
+| `scenarios/case_*.xml` | the six SIPp registrar scenarios |
 
 ## Related unit tests
 

--- a/modules/uac_registrant/test/sipp/db/registrant
+++ b/modules/uac_registrant/test/sipp/db/registrant
@@ -1,0 +1,1 @@
+id(int,auto) registrar(string) proxy(string,null) aor(string) third_party_registrant(string,null) username(string,null) password(string,null) binding_URI(string) binding_params(string,null) expiry(int,null) forced_socket(string,null) cluster_shtag(string,null) state(int) 

--- a/modules/uac_registrant/test/sipp/db/version
+++ b/modules/uac_registrant/test/sipp/db/version
@@ -1,0 +1,2 @@
+table_name(string) table_version(int) 
+registrant:3

--- a/modules/uac_registrant/test/sipp/opensips.cfg.template
+++ b/modules/uac_registrant/test/sipp/opensips.cfg.template
@@ -1,0 +1,47 @@
+#
+# OpenSIPS config for the uac_registrant 423/Min-Expires SIPp test.
+#
+# This is a TEMPLATE. run.sh substitutes the following placeholders and writes
+# a concrete opensips.cfg into a per-run working directory:
+#
+#   @MPATH@      absolute path to the built modules/ directory
+#   @SIP_SOCK@   SIP UDP listen socket  (e.g. udp:127.0.0.1:5060)
+#   @DBDIR@      db_text database dir (holds the empty 'registrant' table)
+#   @FIFO@       MI FIFO path
+#   @REPLYDIR@   MI FIFO reply directory
+#   @STRICT@     value of the min_expires_strict modparam (0 or 1)
+#
+# The registrant itself is NOT defined here; run.sh injects it at runtime with
+# the MI command 'reg_upsert', so a single config drives every test case.
+#
+
+log_level = 3
+stderror_enabled = yes
+syslog_enabled = no
+
+socket = @SIP_SOCK@
+
+mpath = "@MPATH@"
+
+loadmodule "proto_udp.so"
+loadmodule "tm.so"
+loadmodule "uac_auth.so"
+loadmodule "db_text.so"
+loadmodule "mi_fifo.so"
+loadmodule "uac_registrant.so"
+
+modparam("mi_fifo", "fifo_name", "@FIFO@")
+modparam("mi_fifo", "fifo_mode", 0666)
+modparam("mi_fifo", "reply_dir", "@REPLYDIR@")
+
+modparam("uac_registrant", "hash_size", 1)
+modparam("uac_registrant", "timer_interval", 10)
+modparam("uac_registrant", "db_url", "text://@DBDIR@")
+modparam("uac_registrant", "min_expires_strict", @STRICT@)
+
+# Pure UAC: we never receive routed SIP requests here. Replies to our own
+# REGISTERs are consumed by tm and dispatched to the uac_registrant callback,
+# so the script route is never actually run - it only needs to exist.
+route {
+	drop;
+}

--- a/modules/uac_registrant/test/sipp/run.sh
+++ b/modules/uac_registrant/test/sipp/run.sh
@@ -21,6 +21,9 @@
 #   C  M=30  <= W           strict=0  -> retry@30  -> REGISTERED   (legacy/tolerant)
 #   D  no Min-Expires       strict=1  -> error, no retry -> REGISTRAR_ERROR
 #   E  M=60  == W (boundary) strict=1 -> error, no retry -> REGISTRAR_ERROR
+#   F  M=120 > W, then a forced refresh -> retry@120, accept -> REGISTERED, and
+#      the refresh re-REGISTER STILL carries 120 (Min-Expires persisted into the
+#      wanted_expires field, not the ephemeral expires; the #3659 regression).
 #
 # Usage:  ./run.sh [-v] [case ...]      (default: all cases; -v keeps logs)
 #
@@ -45,13 +48,16 @@ EXPIRY=60
 KEEP=0
 [ "${1:-}" = "-v" ] && { KEEP=1; shift; }
 
-# case table: name|scenario|strict|expected_state
+# case table: name|scenario|strict|expected_state[|refresh]
+# the optional 5th field "refresh" forces a second REGISTER once the first cycle
+# has REGISTERED, so the scenario can assert the negotiated expires persisted.
 CASES=(
   "A_conformant|case_A_conformant.xml|1|REGISTERED_STATE"
   "B_low_strict|case_B_low_strict.xml|1|REGISTRAR_ERROR_STATE"
   "C_low_tolerant|case_C_low_tolerant.xml|0|REGISTERED_STATE"
   "D_missing|case_D_missing.xml|1|REGISTRAR_ERROR_STATE"
   "E_equal_strict|case_E_equal_strict.xml|1|REGISTRAR_ERROR_STATE"
+  "F_persist|case_F_persist.xml|1|REGISTERED_STATE|refresh"
 )
 
 # --------------------------------------------------------------------------
@@ -102,6 +108,16 @@ reg_state() {
     '.result.Records[]? | select(.AOR==$aor) | .state' 2>/dev/null | head -1
 }
 
+# block until our registrant reaches REGISTERED (≈15s budget, > timer_interval)
+wait_registered() {
+  local i
+  for i in $(seq 1 75); do
+    [ "$(reg_state)" = "REGISTERED_STATE" ] && return 0
+    sleep 0.2
+  done
+  return 1
+}
+
 # --------------------------------------------------------------------------
 # OpenSIPS lifecycle
 # --------------------------------------------------------------------------
@@ -141,8 +157,8 @@ upsert_registrant() {
 # --------------------------------------------------------------------------
 # One test case
 # --------------------------------------------------------------------------
-run_case() {  # run_case name scenario strict expected_state
-  local name="$1" scn="$2" strict="$3" want="$4"
+run_case() {  # run_case name scenario strict expected_state [refresh]
+  local name="$1" scn="$2" strict="$3" want="$4" refresh="${5:-}"
   RUN="$WORK/$name"; mkdir -p "$RUN"
 
   start_opensips "$strict"
@@ -152,7 +168,9 @@ run_case() {  # run_case name scenario strict expected_state
   fi
 
   # SIPp UAS (registrar). -m 1: one call; exit 0 iff the call matched the script.
-  timeout 40 "$SIPP" "$SIP_IP:$SIP_PORT" \
+  # 60s upper bound: a refresh case runs two register cycles, each gated by the
+  # registrant's timer_interval.
+  timeout 60 "$SIPP" "$SIP_IP:$SIP_PORT" \
       -sf "$HERE/scenarios/$scn" -i "$REG_IP" -p "$REG_PORT" -m 1 \
       -trace_err -error_file "$RUN/sipp.err" \
       -trace_screen -screen_file "$RUN/sipp.screen" \
@@ -161,6 +179,20 @@ run_case() {  # run_case name scenario strict expected_state
 
   sleep 0.5
   upsert_registrant
+
+  # Persistence cases: once the first cycle has REGISTERED, force a re-REGISTER.
+  # The scenario then asserts the refresh STILL carries the negotiated
+  # Min-Expires - i.e. it persisted into wanted_expires, not the ephemeral
+  # expires (the #3659 regression). Same Call-ID, so it stays one SIPp call.
+  if [ "$refresh" = refresh ]; then
+    if wait_registered; then
+      mi reg_force_register "$(jq -n \
+            --arg aor "$AOR" --arg c "$CONTACT" --arg r "$REGISTRAR" \
+            '{aor:$aor, contact:$c, registrar:$r}')" >/dev/null
+    else
+      echo "      (note: $name never reached REGISTERED before the forced refresh)"
+    fi
+  fi
 
   wait "$sipp_pid"; local sipp_rc=$?
 
@@ -193,12 +225,12 @@ echo "uac_registrant 423/Min-Expires SIPp integration test"
 echo "opensips=$OPENSIPS  sipp=$($SIPP -v 2>&1 | grep -oE 'v[0-9.]+' | head -1)"
 echo "------------------------------------------------------------"
 for row in "${CASES[@]}"; do
-  IFS='|' read -r name scn strict want <<<"$row"
+  IFS='|' read -r name scn strict want refresh <<<"$row"
   case "$select" in
     all) : ;;
     *) [[ " $select " == *" $name "* ]] || continue ;;
   esac
-  if run_case "$name" "$scn" "$strict" "$want"; then pass=$((pass+1)); else fail=$((fail+1)); fi
+  if run_case "$name" "$scn" "$strict" "$want" "$refresh"; then pass=$((pass+1)); else fail=$((fail+1)); fi
 done
 echo "------------------------------------------------------------"
 echo "result: $pass passed, $fail failed"

--- a/modules/uac_registrant/test/sipp/run.sh
+++ b/modules/uac_registrant/test/sipp/run.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Integration test for the uac_registrant 423 / Min-Expires handling (gh #3910).
+#
+# A SIPp UAS plays the role of the registrar and answers the registrant's
+# REGISTER with a crafted 423 (Interval Too Brief). A real OpenSIPS instance
+# runs the uac_registrant module under test; the registrant is injected at
+# runtime over the MI FIFO (reg_upsert), so a single config drives every case.
+#
+# Each case asserts two independent things:
+#   1. SIPp verdict      - the on-the-wire behaviour (did the registrant retry,
+#                          and with the right expires?). Positive cases enforce
+#                          the retry's ";expires=" via an ereg check_it; negative
+#                          cases pass iff no retry arrives within the window.
+#   2. MI registrant state - the authoritative outcome of the state machine,
+#                          read back with 'reg_list' (REGISTERED vs REGISTRAR_ERROR).
+#
+# Truth table exercised (W = requested expires = 60, M = Min-Expires):
+#   A  M=120 > W            strict=1  -> retry@120 -> REGISTERED
+#   B  M=30  <= W           strict=1  -> error, no retry -> REGISTRAR_ERROR
+#   C  M=30  <= W           strict=0  -> retry@30  -> REGISTERED   (legacy/tolerant)
+#   D  no Min-Expires       strict=1  -> error, no retry -> REGISTRAR_ERROR
+#   E  M=60  == W (boundary) strict=1 -> error, no retry -> REGISTRAR_ERROR
+#
+# Usage:  ./run.sh [-v] [case ...]      (default: all cases; -v keeps logs)
+#
+set -u
+
+# --------------------------------------------------------------------------
+# Layout / configuration
+# --------------------------------------------------------------------------
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../../.." && pwd)"          # opensips source root
+OPENSIPS="${OPENSIPS_BIN:-$ROOT/opensips}"
+MPATH="${OPENSIPS_MPATH:-$ROOT/modules/}"
+SIPP="${SIPP_BIN:-sipp}"
+
+SIP_IP=127.0.0.1 ;  SIP_PORT=5060               # OpenSIPS SIP listener
+REG_IP=127.0.0.1 ;  REG_PORT=5070               # SIPp registrar (UAS)
+AOR="sip:alice@example.com"
+CONTACT="sip:alice@$SIP_IP:$SIP_PORT"
+REGISTRAR="sip:$REG_IP:$REG_PORT"
+EXPIRY=60
+
+KEEP=0
+[ "${1:-}" = "-v" ] && { KEEP=1; shift; }
+
+# case table: name|scenario|strict|expected_state
+CASES=(
+  "A_conformant|case_A_conformant.xml|1|REGISTERED_STATE"
+  "B_low_strict|case_B_low_strict.xml|1|REGISTRAR_ERROR_STATE"
+  "C_low_tolerant|case_C_low_tolerant.xml|0|REGISTERED_STATE"
+  "D_missing|case_D_missing.xml|1|REGISTRAR_ERROR_STATE"
+  "E_equal_strict|case_E_equal_strict.xml|1|REGISTRAR_ERROR_STATE"
+)
+
+# --------------------------------------------------------------------------
+# Pre-flight
+# --------------------------------------------------------------------------
+[ -x "$OPENSIPS" ] || { echo "opensips binary not found/executable: $OPENSIPS" >&2; exit 2; }
+command -v "$SIPP" >/dev/null   || { echo "sipp not found in PATH" >&2; exit 2; }
+command -v jq >/dev/null        || { echo "jq not found in PATH" >&2; exit 2; }
+
+WORK="$(mktemp -d /tmp/uacreg_sipp.XXXXXX)"
+OPID=""
+cleanup_run() { [ -n "$OPID" ] && kill "$OPID" 2>/dev/null; OPID=""; }
+trap 'cleanup_run; [ "$KEEP" = 1 ] || rm -rf "$WORK"' EXIT
+
+# --------------------------------------------------------------------------
+# MI over the FIFO:  request = ":"reply_fifo":"jsonrpc
+# --------------------------------------------------------------------------
+RUN=""      # set per case
+mi() {      # mi <method> [json-params]
+  # reply-fifo name must not contain '.', '/' or '\' (mi_fifo forbids them)
+  local method="$1" params="${2:-}" rf="mireply_${RANDOM}_${RANDOM}" out
+  local rfpath="$RUN/$rf"
+  rm -f "$rfpath"; mkfifo "$rfpath"
+  ( timeout 5 cat "$rfpath" ) >"$RUN/.mi_out" &
+  local reader=$!
+  if [ -n "$params" ]; then
+    printf ':%s:{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}\n' "$rf" "$method" "$params" >"$RUN/fifo"
+  else
+    printf ':%s:{"jsonrpc":"2.0","id":1,"method":"%s"}\n' "$rf" "$method" >"$RUN/fifo"
+  fi
+  wait $reader 2>/dev/null
+  rm -f "$rfpath"
+  cat "$RUN/.mi_out"
+}
+
+wait_mi_ready() {
+  local i
+  for i in $(seq 1 50); do
+    [ -p "$RUN/fifo" ] && mi reg_list | jq -e . >/dev/null 2>&1 && return 0
+    sleep 0.2
+  done
+  return 1
+}
+
+# state of our single registrant, parsed out of reg_list
+reg_state() {
+  mi reg_list | jq -r --arg aor "$AOR" \
+    '.result.Records[]? | select(.AOR==$aor) | .state' 2>/dev/null | head -1
+}
+
+# --------------------------------------------------------------------------
+# OpenSIPS lifecycle
+# --------------------------------------------------------------------------
+gen_cfg() {  # gen_cfg <strict>
+  sed -e "s#@MPATH@#$MPATH#g" \
+      -e "s#@SIP_SOCK@#udp:$SIP_IP:$SIP_PORT#g" \
+      -e "s#@DBDIR@#$RUN#g" \
+      -e "s#@FIFO@#$RUN/fifo#g" \
+      -e "s#@REPLYDIR@#$RUN/#g" \
+      -e "s#@STRICT@#$1#g" \
+      "$HERE/opensips.cfg.template" >"$RUN/opensips.cfg"
+}
+
+start_opensips() {  # start_opensips <strict>
+  cp "$HERE/db/version" "$HERE/db/registrant" "$RUN/"
+  gen_cfg "$1"
+  # -i : skip the module git-revision cross-check (local build tree may mix
+  #      revisions; version + compile-flags are still verified).
+  # -F : keep the main process in the foreground so $! is the killable PID.
+  "$OPENSIPS" -i -F -f "$RUN/opensips.cfg" -w "$RUN" -P "$RUN/opensips.pid" \
+      >"$RUN/opensips.log" 2>&1 &
+  OPID=$!
+}
+
+upsert_registrant() {
+  mi reg_upsert "$(jq -n \
+      --arg aor "$AOR" --arg c "$CONTACT" --arg r "$REGISTRAR" \
+      --arg u alice --arg p secret --argjson e "$EXPIRY" \
+      '{aor:$aor, contact:$c, registrar:$r, proxy:"", third_party_registrant:"",
+        username:$u, password:$p, binding_params:"", expiry:$e,
+        forced_socket:"", cluster_shtag:"", state:0}')" >/dev/null
+  # ensure it registers at the next timer tick rather than waiting a full cycle
+  mi reg_force_register "$(jq -n --arg aor "$AOR" --arg c "$CONTACT" --arg r "$REGISTRAR" \
+        '{aor:$aor, contact:$c, registrar:$r}')" >/dev/null
+}
+
+# --------------------------------------------------------------------------
+# One test case
+# --------------------------------------------------------------------------
+run_case() {  # run_case name scenario strict expected_state
+  local name="$1" scn="$2" strict="$3" want="$4"
+  RUN="$WORK/$name"; mkdir -p "$RUN"
+
+  start_opensips "$strict"
+  if ! wait_mi_ready; then
+    echo "FAIL  $name : OpenSIPS MI did not come up"; sed -n '1,40p' "$RUN/opensips.log"
+    cleanup_run; return 1
+  fi
+
+  # SIPp UAS (registrar). -m 1: one call; exit 0 iff the call matched the script.
+  timeout 40 "$SIPP" "$SIP_IP:$SIP_PORT" \
+      -sf "$HERE/scenarios/$scn" -i "$REG_IP" -p "$REG_PORT" -m 1 \
+      -trace_err -error_file "$RUN/sipp.err" \
+      -trace_screen -screen_file "$RUN/sipp.screen" \
+      >"$RUN/sipp.out" 2>&1 &
+  local sipp_pid=$!
+
+  sleep 0.5
+  upsert_registrant
+
+  wait "$sipp_pid"; local sipp_rc=$?
+
+  sleep 1
+  local got; got="$(reg_state)"
+  cleanup_run
+
+  local ok=1
+  [ "$sipp_rc" -eq 0 ] || ok=0
+  [ "$got" = "$want" ] || ok=0
+
+  if [ "$ok" = 1 ]; then
+    printf 'PASS  %-15s sipp=ok  state=%s\n' "$name" "$got"
+    return 0
+  else
+    printf 'FAIL  %-15s sipp_rc=%s  state=%s (expected %s)\n' "$name" "$sipp_rc" "${got:-<none>}" "$want"
+    echo "      --- opensips uac_registrant log (filtered) ---"
+    grep -iE "min-expires|423|registrar error|bogus|non-conformant|REGISTER" "$RUN/opensips.log" | sed 's/^/      /' | tail -15
+    echo "      --- sipp errors ---"; sed 's/^/      /' "$RUN/sipp.err" 2>/dev/null | tail -15
+    return 1
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+select="${*:-all}"
+pass=0; fail=0
+echo "uac_registrant 423/Min-Expires SIPp integration test"
+echo "opensips=$OPENSIPS  sipp=$($SIPP -v 2>&1 | grep -oE 'v[0-9.]+' | head -1)"
+echo "------------------------------------------------------------"
+for row in "${CASES[@]}"; do
+  IFS='|' read -r name scn strict want <<<"$row"
+  case "$select" in
+    all) : ;;
+    *) [[ " $select " == *" $name "* ]] || continue ;;
+  esac
+  if run_case "$name" "$scn" "$strict" "$want"; then pass=$((pass+1)); else fail=$((fail+1)); fi
+done
+echo "------------------------------------------------------------"
+echo "result: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/modules/uac_registrant/test/sipp/scenarios/case_A_conformant.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_A_conformant.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case A: CONFORMANT 423 (Min-Expires > requested).
+     The registrant requests expires=60. We answer 423 with Min-Expires:120,
+     which RFC 3261 10.3 permits (120 > 60). The registrant MUST retry with
+     expires=120, which we then accept. Expected final state: REGISTERED.
+     This works regardless of min_expires_strict. -->
+<scenario name="uac_registrant registrar - conformant 423 (Min-Expires &gt; requested)">
+
+  <!-- 1) initial REGISTER, must carry the requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 Interval Too Brief, Min-Expires:120 (conformant) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagA[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Min-Expires: 120
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) the retry REGISTER must now carry expires=120 (the advertised
+          Min-Expires). check_it fails the call if it does not. -->
+  <recv request="REGISTER" timeout="8000">
+    <action>
+      <ereg regexp="expires=120([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 4) accept the registration (echo the Contact, which carries expires=120) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagA[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+[last_Contact:]
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="1000"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/sipp/scenarios/case_B_low_strict.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_B_low_strict.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case B: NON-CONFORMANT 423 (Min-Expires <= requested) with
+     min_expires_strict=1 (default / strict).
+     The registrant requests expires=60. We answer 423 with Min-Expires:30,
+     which is non-conformant (30 is not greater than 60). With the default
+     strict behavior the registrant MUST treat this as a registrar error and
+     MUST NOT retry (no endless REGISTER/423 loop). Expected final state:
+     REGISTRAR_ERROR.
+
+     SIPp verdict: the second <recv> is expected to TIME OUT (no retry). If a
+     retry REGISTER does arrive, we fall through to a recv that times out with
+     no ontimeout, which fails the call. The authoritative assertion is the
+     registrant state queried over MI by run.sh. -->
+<scenario name="uac_registrant registrar - non-conformant 423, strict (no retry)">
+
+  <!-- 1) initial REGISTER, requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 with a non-conformant Min-Expires:30 (<= requested 60) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagB[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Min-Expires: 30
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) we must NOT receive another REGISTER. Timing out here is the PASS
+          path (ontimeout jumps to the end). -->
+  <recv request="REGISTER" timeout="6000" ontimeout="99">
+    <action>
+      <log message="FAIL: registrant retried a non-conformant 423 under strict mode"/>
+    </action>
+  </recv>
+
+  <!-- 4) only reached if a (forbidden) retry arrived: force the call to fail -->
+  <recv request="ACK" timeout="500"/>
+
+  <!-- 99) timeout path: no retry was sent => PASS -->
+  <label id="99"/>
+  <timewait milliseconds="500"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/sipp/scenarios/case_C_low_tolerant.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_C_low_tolerant.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case C: NON-CONFORMANT 423 (Min-Expires <= requested) with
+     min_expires_strict=0 (legacy / tolerant).
+     The registrant requests expires=60. We answer 423 with Min-Expires:30,
+     which is non-conformant (30 is not greater than 60). With
+     min_expires_strict=0 the registrant tolerates it and retries with the
+     advertised value (30). We then accept. Expected final state: REGISTERED. -->
+<scenario name="uac_registrant registrar - non-conformant 423, tolerant (strict=0)">
+
+  <!-- 1) initial REGISTER, requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 with a non-conformant Min-Expires:30 (<= requested 60) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagC[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Min-Expires: 30
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) with strict=0 the registrant retries with the advertised value (30) -->
+  <recv request="REGISTER" timeout="8000">
+    <action>
+      <ereg regexp="expires=30([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 4) accept -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagC[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+[last_Contact:]
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="1000"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/sipp/scenarios/case_D_missing.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_D_missing.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case D: 423 with NO (parsable) Min-Expires header.
+     The registrant requests expires=60. We answer 423 but omit Min-Expires
+     entirely. There is no value to retry with, so the registrant MUST treat
+     this as a registrar error and MUST NOT retry - regardless of
+     min_expires_strict. Expected final state: REGISTRAR_ERROR.
+
+     SIPp verdict: as in case B, the second <recv> is expected to TIME OUT. A
+     retry would fail the call; the authoritative check is the MI state. -->
+<scenario name="uac_registrant registrar - 423 without Min-Expires (no retry)">
+
+  <!-- 1) initial REGISTER, requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 with NO Min-Expires header at all -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagD[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) we must NOT receive another REGISTER. Timing out here is the PASS path. -->
+  <recv request="REGISTER" timeout="6000" ontimeout="99">
+    <action>
+      <log message="FAIL: registrant retried a 423 that had no Min-Expires"/>
+    </action>
+  </recv>
+
+  <!-- 4) only reached if a (forbidden) retry arrived: force the call to fail -->
+  <recv request="ACK" timeout="500"/>
+
+  <!-- 99) timeout path: no retry was sent => PASS -->
+  <label id="99"/>
+  <timewait milliseconds="500"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/sipp/scenarios/case_E_equal_strict.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_E_equal_strict.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case E: BOUNDARY 423 where Min-Expires == requested, strict (default).
+     The registrant requests expires=60. We answer 423 with Min-Expires:60,
+     i.e. exactly equal to the requested value. RFC 3261 only allows 423 when
+     the request is strictly smaller than the registrar minimum, so equal is
+     non-conformant. The code's test is a strict '>' (exp > wanted_expires), so
+     under the default strict mode this MUST be treated as a registrar error
+     with NO retry. This case exists specifically to pin that the operator is
+     '>' and not '>=' (a '>=' bug would wrongly accept Min-Expires == requested).
+     Expected final state: REGISTRAR_ERROR. -->
+<scenario name="uac_registrant registrar - boundary 423 Min-Expires == requested, strict">
+
+  <!-- 1) initial REGISTER, requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 with Min-Expires:60 (equal to requested -> non-conformant) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagE[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Min-Expires: 60
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) we must NOT receive another REGISTER (strict '>' rejects equal). -->
+  <recv request="REGISTER" timeout="6000" ontimeout="99">
+    <action>
+      <log message="FAIL: registrant retried a 423 with Min-Expires == requested under strict mode"/>
+    </action>
+  </recv>
+
+  <!-- 4) only reached if a (forbidden) retry arrived: force the call to fail -->
+  <recv request="ACK" timeout="500"/>
+
+  <!-- 99) timeout path: no retry was sent => PASS -->
+  <label id="99"/>
+  <timewait milliseconds="500"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/sipp/scenarios/case_F_persist.xml
+++ b/modules/uac_registrant/test/sipp/scenarios/case_F_persist.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<!DOCTYPE scenario SYSTEM "sipp.dtd">
+
+<!-- Case F: PERSISTENCE of the negotiated Min-Expires across a refresh.
+
+     Mirrors the regression bogdan-iancu described on #3910: the #3659 change
+     made the record's "expires" field ephemeral (re-seeded from wanted_expires
+     each cycle), so a 423's Min-Expires must be stored in the *persistent*
+     wanted_expires - otherwise not the immediate retry but every LATER
+     re-REGISTER reverts to the originally requested value.
+
+     The registrant requests expires=60; we answer 423 with Min-Expires:120
+     (conformant, 120 > 60). It retries at 120 and we accept. Then the harness
+     forces a re-REGISTER (refresh): that refresh MUST again carry expires=120.
+     If the negotiated value lived in the ephemeral "expires" field it would
+     revert to 60 here and this check_it would fail the call.
+
+     The REGISTERED->refresh path does not regenerate the Call-ID, so both the
+     first cycle and the refresh are one SIPp call (-m 1). Expected final state:
+     REGISTERED. Independent of min_expires_strict (this is a conformant 423). -->
+<scenario name="uac_registrant registrar - Min-Expires persistence across refresh">
+
+  <!-- 1) initial REGISTER, requested expires=60 -->
+  <recv request="REGISTER">
+    <action>
+      <ereg regexp="expires=60([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 2) reply 423 Interval Too Brief, Min-Expires:120 (conformant) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 423 Interval Too Brief
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagF[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+Min-Expires: 120
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 3) the retry REGISTER must carry the advertised expires=120 -->
+  <recv request="REGISTER" timeout="8000">
+    <action>
+      <ereg regexp="expires=120([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="matched [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 4) accept the registration (Contact echoes expires=120) -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagF[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+[last_Contact:]
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <!-- 5) THE CRUX: after the harness forces a re-REGISTER, the refresh must
+          STILL carry expires=120. A revert to 60 (negotiated value not made
+          persistent) fails the call here. Generous timeout to span the
+          registrant's timer_interval. -->
+  <recv request="REGISTER" timeout="20000">
+    <action>
+      <ereg regexp="expires=120([^0-9]|$)" search_in="msg" check_it="true"
+            assign_to="junk"/>
+      <log message="refresh persisted [$junk]"/>
+    </action>
+  </recv>
+
+  <!-- 6) accept the refreshed registration -->
+  <send>
+    <![CDATA[
+
+SIP/2.0 200 OK
+[last_Via:]
+[last_From:]
+[last_To:];tag=[pid]SIPpTagF[call_number]
+[last_Call-ID:]
+[last_CSeq:]
+[last_Contact:]
+Content-Length: 0
+
+    ]]>
+  </send>
+
+  <timewait milliseconds="1000"/>
+
+  <ResponseTimeRepartition value="100, 500, 1000, 2000"/>
+</scenario>

--- a/modules/uac_registrant/test/test.c
+++ b/modules/uac_registrant/test/test.c
@@ -1,0 +1,109 @@
+/*
+ * Unit tests (TAP) for the uac_registrant 423 / Min-Expires decision logic.
+ *
+ * Run with:  make test module=uac_registrant
+ *
+ * This file is part of opensips, a free SIP server.
+ *
+ * opensips is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version
+ *
+ * opensips is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,USA
+ */
+
+#include <tap.h>
+
+#include "../min_expires.h"
+
+/*
+ * min_expires_decide(min_expires, wanted_expires, strict)
+ *
+ * Truth table being pinned (M = Min-Expires from the 423, 0 when the header was
+ * missing/unparsable; W = wanted/requested expires):
+ *
+ *   reply                         strict=1              strict=0
+ *   ---------------------------   --------------------  --------------------
+ *   M >  W (conformant)           ME_RETRY_CONFORMANT   ME_RETRY_CONFORMANT
+ *   M == W (boundary)             ME_ERR_NONCONFORMANT  ME_RETRY_TOLERATED
+ *   M <  W                        ME_ERR_NONCONFORMANT  ME_RETRY_TOLERATED
+ *   M == 0 (or no/unparsable hdr) ME_ERR_NO_VALUE       ME_ERR_NO_VALUE
+ *   M >  MAX_SANE                 ME_ERR_INSANE         ME_ERR_INSANE
+ *
+ * Two values are special, errors even in tolerant mode: 0 (retrying with it
+ * would put Expires: 0 on the wire - a de-registration) and anything above
+ * UAC_REG_MAX_SANE_EXPIRES (a broken registrar we refuse rather than adopt).
+ * A missing/unparsable header is expressed as M == 0 (the caller passes 0 for
+ * it): the two are indistinguishable here by design and share ME_ERR_NO_VALUE.
+ */
+static void test_min_expires_decide(void)
+{
+	/* conformant: Min-Expires strictly greater than requested -> always retry */
+	ok(min_expires_decide(120, 60, 1) == ME_RETRY_CONFORMANT,
+		"conformant (120>60), strict: conformant retry");
+	ok(min_expires_decide(120, 60, 0) == ME_RETRY_CONFORMANT,
+		"conformant (120>60), tolerant: conformant retry");
+	ok(min_expires_decide(61, 60, 1) == ME_RETRY_CONFORMANT,
+		"just above (61>60), strict: conformant retry");
+	ok(min_expires_decide(7200, 3600, 1) == ME_RETRY_CONFORMANT,
+		"conformant at larger scale, strict: conformant retry");
+
+	/* boundary: Min-Expires == requested. The comparison must be a strict
+	 * '>', not '>=' - this is the off-by-one that the patch hinges on. */
+	ok(min_expires_decide(60, 60, 1) == ME_ERR_NONCONFORMANT,
+		"equal (60==60), strict: registrar error (not '>=')");
+	ok(min_expires_decide(60, 60, 0) == ME_RETRY_TOLERATED,
+		"equal (60==60), tolerant: tolerated retry");
+	ok(min_expires_decide(3600, 3600, 1) == ME_ERR_NONCONFORMANT,
+		"equal at larger scale, strict: registrar error");
+
+	/* non-conformant: Min-Expires below requested */
+	ok(min_expires_decide(30, 60, 1) == ME_ERR_NONCONFORMANT,
+		"below (30<60), strict: registrar error");
+	ok(min_expires_decide(30, 60, 0) == ME_RETRY_TOLERATED,
+		"below (30<60), tolerant: tolerated retry");
+	ok(min_expires_decide(59, 60, 1) == ME_ERR_NONCONFORMANT,
+		"just below (59<60), strict: registrar error");
+
+	/* absurd minimum: above UAC_REG_MAX_SANE_EXPIRES is a broken registrar -
+	 * refuse it in both modes rather than adopt a pathological interval. The
+	 * boundary value itself (== MAX) is still a normal conformant retry. */
+	ok(min_expires_decide(UAC_REG_MAX_SANE_EXPIRES + 1, 3600, 1)
+			== ME_ERR_INSANE,
+		"above sane maximum, strict: registrar error");
+	ok(min_expires_decide(UAC_REG_MAX_SANE_EXPIRES + 1, 3600, 0)
+			== ME_ERR_INSANE,
+		"above sane maximum, tolerant: registrar error (no unbounded ratchet)");
+	ok(min_expires_decide(UAC_REG_MAX_SANE_EXPIRES, 3600, 1)
+			== ME_RETRY_CONFORMANT,
+		"exactly at sane maximum, strict: still a conformant retry");
+
+	/* Min-Expires: 0 - or, equivalently, a missing/unparsable header (the
+	 * caller passes 0 for both). Retrying with it would send Expires: 0 (a
+	 * de-registration) while the record still believes it is REGISTERED, so it
+	 * is an error in BOTH modes - tolerant must not flip it. */
+	ok(min_expires_decide(0, 60, 1) == ME_ERR_NO_VALUE,
+		"zero/missing Min-Expires, strict: registrar error");
+	ok(min_expires_decide(0, 60, 0) == ME_ERR_NO_VALUE,
+		"zero/missing Min-Expires, tolerant: registrar error (never self-de-register)");
+
+	/* strict only changes the outcome of the non-conformant, non-zero rows
+	 * (the zero row stays an error in both modes - tested above) */
+	ok(min_expires_decide(50, 60, 1) != min_expires_decide(50, 60, 0),
+		"strict flips the non-conformant case");
+	ok(min_expires_decide(90, 60, 1) == min_expires_decide(90, 60, 0),
+		"strict does not affect the conformant case");
+}
+
+void mod_tests(void)
+{
+	test_min_expires_decide();
+}


### PR DESCRIPTION
## uac_registrant: proper, tested handling of 423 (Interval Too Brief) with Min-Expires

Fixes the registrant's handling of a `423 (Interval Too Brief)` reply
(GitHub #3910) and hardens the surrounding edge cases, with unit and
integration test coverage.

### Background

Per RFC 3261 §10.3, a registrar may only answer `423` when the requested
expiration is **smaller** than its configured minimum, advertising that
minimum in a `Min-Expires` header. §10.2.8 then requires the UAC to retry
with an expiration **≥ Min-Expires**. The previous code retried with the
*originally rejected* value instead of the advertised minimum, producing an
endless `REGISTER` / `423` loop (or registration at an insufficient interval).

### What this PR does

- **Retries with the registrar's `Min-Expires`** and **persists** it as the
  requested expiration, so the interval is renegotiated once rather than
  incurring a `423` round-trip on every refresh.
- **Factors the policy into a pure, side-effect-free helper**
  `min_expires_decide()` (`min_expires.{c,h}`) returning a reason-bearing
  outcome (`ME_RETRY_CONFORMANT`, `ME_RETRY_TOLERATED`, `ME_ERR_NO_VALUE`,
  `ME_ERR_INSANE`, `ME_ERR_NONCONFORMANT`) — the single source of truth for
  both the decision and the error reason. The call site is a flat `switch`
  that maps each outcome straight to its log message and state transition,
  with no re-derivation of the function's predicates. The full RFC-3261
  rationale and truth table live once beside the enum, and the function is
  unit-tested as a standalone translation unit.
- **Hardens the edge cases the inline version mishandled:**
  - `Min-Expires: 0` is **always** a registrar error, even in tolerant mode —
    the old code would retry with `Expires: 0`, a silent self-de-registration
    while the record still believed it was `REGISTERED`.
  - A `Min-Expires` above a sane maximum (`UAC_REG_MAX_SANE_EXPIRES`, one day)
    is refused rather than adopted; clamping below the demanded minimum would
    just earn another `423`, and adopting it would ratchet the requested expiry
    to a pathological value.
  - A missing/unparsable `Min-Expires` remains a registrar error.
- **`min_expires_strict` modparam** (default `1`) preserves backward
  compatibility: with `0`, a non-conformant `423` (`Min-Expires` not greater
  than requested, but usable) is tolerated and retried with the advertised
  value. The `0` and over-maximum cases are errors regardless of this setting.

### Behaviour (truth table, `W` = requested expires)

| 423 reply | `min_expires_strict=1` (default) | `min_expires_strict=0` |
|---|---|---|
| `Min-Expires > W` (conformant) | retry with Min-Expires | retry with Min-Expires |
| `Min-Expires == W` (boundary) | registrar error | retry (tolerated) |
| `Min-Expires < W` | registrar error | retry (tolerated) |
| `Min-Expires == 0` | registrar error | registrar error |
| `Min-Expires > 1 day` | registrar error | registrar error |
| missing / unparsable | registrar error | registrar error |

### Testing

- **TAP unit tests** (`test/test.c`) pin the full truth table — 20 assertions,
  including the strict `>` boundary, the `Min-Expires: 0` case and the
  over-maximum case. Run with `make test module=uac_registrant` → `1..20`,
  all `ok`.
- **SIPp integration harness** (`test/sipp/`) drives a real OpenSIPS instance
  against a SIPp registrar that returns crafted `423`s, asserting both the
  on-wire retry `;expires=` and the resulting MI registrant state. Cases A–E
  cover conformant / low-strict / low-tolerant / missing / boundary →
  `5 passed, 0 failed`.

### Docs

Admin guide documents `min_expires_strict`, the tolerant-mode wording, the
persistence behaviour and the refusal cases; `test/sipp/README.md` documents
how to run the suites and their expected output.

### Commits

- `uac_registrant: proper handling of 423 with Min-Expires (#3910)`
- `uac_registrant: factor 423/Min-Expires decision into a tested helper`
- `uac_registrant: document Min-Expires persistence and verified test output`
