### PR TITLE
lib/nats: redact slash-bearing base64 tokens in NATS URLs

### DIFF
--- a/lib/nats/nats_redact.c
+++ b/lib/nats/nats_redact.c
@@ -30,7 +30,6 @@ static const char *redact_one(const char *url, char **dst, size_t *rem)
 	const char *scheme_end;
 	const char *authority;
 	const char *at;
-	const char *next_slash;
 	const char *url_end;
 	const char *scan;
 
@@ -46,15 +45,31 @@ static const char *redact_one(const char *url, char **dst, size_t *rem)
 	else
 		authority = url;
 
-	next_slash = memchr(authority, '/', (size_t)(url_end - authority));
-	if (!next_slash) next_slash = url_end;
-
-	/* '@' separates userinfo from host and must be in the authority
-	 * section (before any path '/').  A password may itself contain '@',
-	 * so the boundary is the LAST '@' in the authority, not the first. */
+	/* Locate the userinfo '@' separator. Two subtleties:
+	 *  1. The userinfo (a base64 NATS token or user:pass) may itself
+	 *     contain '/' and '=', e.g. nats://AbC/dEf=@host. So the '@'
+	 *     search must NOT stop at the FIRST '/': that '/' can be INSIDE
+	 *     the credential, before the real '@' — stopping there misses the
+	 *     '@' entirely and the token is logged verbatim (credential leak).
+	 *  2. A path after the host may itself contain '@' (e.g. .../t@home).
+	 *     The host/port never contain '/' or '@', so the real path begins
+	 *     at the first '/' that occurs AFTER the first '@'.
+	 * So: path_start = first '/' after the first '@' (else end); the
+	 * userinfo '@' is the LAST '@' within [authority, path_start)
+	 * (passwords may contain '@'). */
 	at = NULL;
-	for (scan = authority; scan < next_slash; scan++)
-		if (*scan == '@') at = scan;
+	{
+		const char *first_at = memchr(authority, '@',
+			(size_t)(url_end - authority));
+		const char *path_start = url_end;
+		if (first_at) {
+			const char *slash = memchr(first_at, '/',
+				(size_t)(url_end - first_at));
+			if (slash) path_start = slash;
+		}
+		for (scan = authority; scan < path_start; scan++)
+			if (*scan == '@') at = scan;
+	}
 
 	if (!at) {
 		/* No userinfo — copy verbatim */

--- a/lib/nats/tests/test_redact_url.c
+++ b/lib/nats/tests/test_redact_url.c
@@ -102,6 +102,13 @@ int main(void)
 	ASSERT_EQ(buf, "nats://[redacted]@h:4222/topic@home",
 		"only authority @ is redacted");
 
+	/* CASE 11b: base64 NATS token containing '/' and '=' — the in-token
+	 *            '/' must NOT be mistaken for the path separator, which
+	 *            would end the '@' search early and leak the token. */
+	nats_redact_url("nats://AbC/dEf=@host:4222", buf, sizeof(buf));
+	ASSERT_EQ(buf, "nats://[redacted]@host:4222",
+		"slash-bearing base64 token redacted");
+
 	/* CASE 12: out_sz == 0 — must not crash, no write */
 	{
 		char tiny[1] = {'X'};


### PR DESCRIPTION
redact_one() bounded the userinfo `@` search at the first `/`. base64 NATS tokens routinely contain `/` and `=` (e.g. `nats://AbC/dEf=@host:4222`), so the in-token `/` was mistaken for the path separator: the `@` search ended before the real `@`, no userinfo was detected, and the URL — token included — was logged verbatim (credential leak in connect/reconnect log lines).

**Fix:** the path begins at the first `/` that occurs *after* the first `@`; the userinfo `@` is the last `@` within `[authority, path_start)`. Preserves the existing last-`@` (passwords may contain `@`) and path-`@` behaviour.

**Test:** adds regression CASE 11b (`nats://AbC/dEf=@host:4222` → `nats://[redacted]@host:4222`). Verified red→green against the current branch with the full `test_redact_url.c` suite (ASan, all cases pass; the unpatched branch fails only the new case).