### PR TITLE
cachedb_nats/nats_consumer: adversarial-audit correctness & security fixes

### DIFF
--- a/lib/nats/nats_rank.c
+++ b/lib/nats/nats_rank.c
@@ -36,11 +36,20 @@
 int nats_pool_should_init(int rank)
 {
 	/*
-	 * SIP workers (UDP + TCP, rank >= 1) and the HTTPD/MI process
-	 * (PROC_MODULE) are the only ranks that should initialize NATS.
-	 * Everything else (attendant, timer, TCP-main, module-exported
-	 * processes) either does not run SIP routing or has its own
-	 * explicit initialization path.
+	 * Ranks that must be able to PUBLISH to NATS:
+	 *   - SIP workers (UDP + TCP, rank >= 1): route-driven events + KV ops.
+	 *   - PROC_MODULE (HTTPD/MI): script/MI-driven publishes.
+	 *   - PROC_TIMER: the OpenSIPS timer process raises a large class of
+	 *     subscribable events SYNCHRONOUSLY in-process -- usrloc contact/AoR
+	 *     EXPIRY (E_UL_CONTACT_EXPIRED ...), dialog timeouts, tm timers.
+	 *     event_nats' raise callback runs in whatever process fires the
+	 *     event, so without a connection here every timer-raised NATS
+	 *     publish is dropped and mis-counted as a transient failure.  Many
+	 *     of the module's headline events (registration/dialog lifecycle)
+	 *     are timer-driven, so the timer MUST initialize.
+	 * Everything else (attendant PROC_MAIN, PROC_TCP_MAIN, module-exported
+	 * forks like the consumer/watcher procs) either does not raise events or
+	 * has its own explicit initialization path.
 	 */
-	return (rank == PROC_MODULE || rank >= 1);
+	return (rank == PROC_MODULE || rank == PROC_TIMER || rank >= 1);
 }

--- a/lib/nats/nats_str.h
+++ b/lib/nats/nats_str.h
@@ -62,6 +62,19 @@ static inline int nats_str_to_buf(const str *s, char *buf, size_t buf_size)
 		LM_ERR("string too long (%d >= %zu)\n", s->len, buf_size);
 		return -1;
 	}
+	/* Reject an embedded NUL: the caller hands the resulting C string to the
+	 * NATS *String KV API (kvStore_PutString / CreateString / UpdateString),
+	 * which stops at the first NUL and would SILENTLY TRUNCATE a NUL-bearing
+	 * value on write while the length-aware read path preserves it -- a lossy
+	 * set/get round-trip.  Fail closed instead (keys never legitimately carry
+	 * a NUL; the usrloc row payload uses length-aware natsMsg_Create, not this
+	 * helper). */
+	if (memchr(s->s, '\0', s->len)) {
+		LM_ERR("string contains an embedded NUL (%d bytes) -- refusing "
+			"(the NATS C-string KV API would silently truncate it)\n",
+			s->len);
+		return -1;
+	}
 	memcpy(buf, s->s, s->len);
 	buf[s->len] = '\0';
 	return 0;

--- a/lib/nats/test_nats_rank.c
+++ b/lib/nats/test_nats_rank.c
@@ -21,7 +21,8 @@ struct rank_case {
 
 static const struct rank_case cases[] = {
 	{ PROC_MAIN,      0, "PROC_MAIN (0, attendant)" },
-	{ PROC_TIMER,     0, "PROC_TIMER (-1)" },
+	{ PROC_TIMER,     1, "PROC_TIMER (-1) -- must init: usrloc/dialog "
+	                     "expiry events are raised here" },
 	{ PROC_MODULE,    1, "PROC_MODULE (-2, HTTPD/MI)" },
 	{ PROC_TCP_MAIN,  0, "PROC_TCP_MAIN (-4, TLS holder)" },
 	{ -3,             0, "rank -3 (module-exported)" },

--- a/modules/cachedb_nats/cachedb_nats_dbase.c
+++ b/modules/cachedb_nats/cachedb_nats_dbase.c
@@ -592,9 +592,15 @@ static int nats_cache_counter_op(cachedb_con *con, str *attr, int delta,
 			 * destroy immediately — we don't need it after this. */
 			const char *vs = nats_dl.kvEntry_ValueString(entry);
 			long long parsed;
+			char cur_txt[64];
 			errno = 0;
 			parsed = vs ? strtoll(vs, NULL, 10) : 0;
 			last_rev = nats_dl.kvEntry_Revision(entry);
+			/* Snapshot the value text for diagnostics BEFORE destroying the
+			 * entry: kvEntry_ValueString returns a pointer INTO the entry's
+			 * own buffer, so logging vs after kvEntry_Destroy would be a
+			 * use-after-free read. */
+			snprintf(cur_txt, sizeof(cur_txt), "%s", vs ? vs : "(null)");
 			nats_dl.kvEntry_Destroy(entry);
 			entry = NULL;
 			/* Counters are 32-bit from the script API; a broker value
@@ -602,7 +608,7 @@ static int nats_cache_counter_op(cachedb_con *con, str *attr, int delta,
 			 * overflow/truncate below.  Reject rather than wrap. */
 			if (errno == ERANGE || parsed < INT_MIN || parsed > INT_MAX) {
 				LM_ERR("counter '%s' stored value out of 32-bit range "
-					"('%s'); refusing op\n", key_buf, vs ? vs : "(null)");
+					"('%s'); refusing op\n", key_buf, cur_txt);
 				return -1;
 			}
 			current = parsed;

--- a/modules/cachedb_nats/cachedb_nats_dbase.c
+++ b/modules/cachedb_nats/cachedb_nats_dbase.c
@@ -534,6 +534,33 @@ int nats_cache_remove_unsupported(cachedb_con *con, str *attr, const str *key)
  * @param new_val  [out] Receives the new counter value on success (may be NULL).
  * @return  0 on success, -1 on error or CAS exhaustion.
  */
+/* Strictly parse a stored counter value: a pure (optionally signed,
+ * whitespace-padded) base-10 integer within the 32-bit range.  Returns 0 and
+ * sets *out on success; -1 if the value is non-numeric, carries trailing
+ * garbage, or is out of range -- a corrupt/hostile broker value.  A NULL value
+ * (the counter does not exist yet) parses as 0, the create path.  strtoll alone
+ * is not enough: it returns 0 with no error for a non-numeric value like "abc",
+ * which would silently RESET the counter to `delta` instead of rejecting it. */
+static int nats_counter_parse(const char *s, long long *out)
+{
+	char *endp;
+	long long v;
+
+	if (!s) { *out = 0; return 0; }
+	errno = 0;
+	v = strtoll(s, &endp, 10);
+	if (endp == s)                       /* no digits consumed */
+		return -1;
+	while (*endp == ' ' || *endp == '\t' || *endp == '\n' || *endp == '\r')
+		endp++;
+	if (*endp != '\0')                   /* trailing garbage after the number */
+		return -1;
+	if (errno == ERANGE || v < INT_MIN || v > INT_MAX)
+		return -1;
+	*out = v;
+	return 0;
+}
+
 static int nats_cache_counter_op(cachedb_con *con, str *attr, int delta,
 	int expires, int *new_val)
 {
@@ -591,24 +618,22 @@ static int nats_cache_counter_op(cachedb_con *con, str *attr, int delta,
 			/* kvEntry lifecycle: extract value + revision, then
 			 * destroy immediately — we don't need it after this. */
 			const char *vs = nats_dl.kvEntry_ValueString(entry);
-			long long parsed;
+			long long parsed = 0;
 			char cur_txt[64];
-			errno = 0;
-			parsed = vs ? strtoll(vs, NULL, 10) : 0;
+			/* Parse WHILE the entry is alive (vs points into it), then
+			 * snapshot the text for diagnostics before destroying it --
+			 * logging vs after kvEntry_Destroy would be a use-after-free.
+			 * nats_counter_parse rejects a non-numeric / out-of-32-bit-range
+			 * value rather than silently treating "abc" as 0 (which would
+			 * reset the counter) or wrapping an over-range value. */
+			int bad = nats_counter_parse(vs, &parsed) < 0;
 			last_rev = nats_dl.kvEntry_Revision(entry);
-			/* Snapshot the value text for diagnostics BEFORE destroying the
-			 * entry: kvEntry_ValueString returns a pointer INTO the entry's
-			 * own buffer, so logging vs after kvEntry_Destroy would be a
-			 * use-after-free read. */
 			snprintf(cur_txt, sizeof(cur_txt), "%s", vs ? vs : "(null)");
 			nats_dl.kvEntry_Destroy(entry);
 			entry = NULL;
-			/* Counters are 32-bit from the script API; a broker value
-			 * outside that range is corrupt or hostile and would
-			 * overflow/truncate below.  Reject rather than wrap. */
-			if (errno == ERANGE || parsed < INT_MIN || parsed > INT_MAX) {
-				LM_ERR("counter '%s' stored value out of 32-bit range "
-					"('%s'); refusing op\n", key_buf, cur_txt);
+			if (bad) {
+				LM_ERR("counter '%s' stored value is not a valid 32-bit "
+					"integer ('%s'); refusing op\n", key_buf, cur_txt);
 				return -1;
 			}
 			current = parsed;
@@ -781,12 +806,13 @@ int nats_cache_get_counter(cachedb_con *con, str *attr, int *val)
 	 * than silently truncated. */
 	{
 		const char *val_str = nats_dl.kvEntry_ValueString(entry);
-		long long parsed;
-		errno = 0;
-		parsed = val_str ? strtoll(val_str, NULL, 10) : 0;
-		if (errno == ERANGE || parsed < INT_MIN || parsed > INT_MAX) {
-			LM_ERR("counter '%s' value out of 32-bit range ('%s')\n",
-				key_buf, val_str ? val_str : "(null)");
+		long long parsed = 0;
+		/* Reject a non-numeric / out-of-32-bit-range stored value rather than
+		 * silently returning 0 (strtoll's result for "abc") or a truncated
+		 * int.  Parse while the entry is alive; val_str points into it. */
+		if (nats_counter_parse(val_str, &parsed) < 0) {
+			LM_ERR("counter '%s' value is not a valid 32-bit integer "
+				"('%s')\n", key_buf, val_str ? val_str : "(null)");
 			nats_dl.kvEntry_Destroy(entry);
 			return -1;
 		}

--- a/modules/cachedb_nats/cachedb_nats_json.c
+++ b/modules/cachedb_nats/cachedb_nats_json.c
@@ -79,6 +79,12 @@ static nats_idx_entry *_lookup(const char *field, int flen,
 	char fv_buf[1024];
 	int fv_len;
 
+	/* Guard negative lengths before the size math: a negative flen/vlen
+	 * could keep fv_len under the ceiling below yet sign-extend to a huge
+	 * size_t in memcpy (OOB).  Mirrors the other fv-builders. */
+	if (flen < 0 || vlen < 0)
+		return NULL;
+
 	fv_len = flen + 1 + vlen;
 	if (fv_len >= (int)sizeof(fv_buf))
 		return NULL;
@@ -99,9 +105,12 @@ static int _lookup_shard(const char *field, int flen,
 	const char *val, int vlen)
 {
 	char fv_buf[1024];
-	int fv_len = flen + 1 + vlen;
+	int fv_len;
 	unsigned int b;
 
+	if (flen < 0 || vlen < 0)
+		return -1;
+	fv_len = flen + 1 + vlen;
 	if (fv_len >= (int)sizeof(fv_buf))
 		return -1;
 	memcpy(fv_buf, field, flen);

--- a/modules/cachedb_nats/cachedb_nats_json.c
+++ b/modules/cachedb_nats/cachedb_nats_json.c
@@ -1339,6 +1339,24 @@ static int _update_fetch_or_seed(nats_cachedb_con *ncon,
 	json_buf[data_len] = '\0';
 
 	nats_dl.kvEntry_Destroy(entry);
+
+	/* Fail closed on an embedded NUL.  data_len is the authoritative
+	 * kvEntry_ValueLen, but the downstream merge (_update_apply_and_cas)
+	 * measures the doc with strlen -- a doc carrying an embedded NUL would
+	 * be truncated at the NUL, merged, and CAS-written back as a
+	 * structurally-valid but SHORT document, silently dropping every
+	 * contact after the NUL.  The read/query path already rejects a raw NUL
+	 * via _json_parse_guard; mirror that here rather than laundering a
+	 * poison doc into a valid-looking truncated one. */
+	if ((int)strlen(json_buf) != data_len) {
+		LM_ERR("update: stored doc for key '%s' has an embedded NUL "
+			"(value %d bytes, strlen %d) -- refusing to merge/writeback "
+			"a truncated document\n",
+			target_key, data_len, (int)strlen(json_buf));
+		free(json_buf);
+		return -1;
+	}
+
 	*out_json = json_buf;
 	return 0;
 }

--- a/modules/cachedb_nats/cachedb_nats_native.c
+++ b/modules/cachedb_nats/cachedb_nats_native.c
@@ -1160,19 +1160,26 @@ static int raw_kv_bucket_info(kvStore *kv, cdb_raw_entry ***reply,
 		return -1;
 	}
 
-	/* allocate 1 row with 6 columns */
+	/* Allocate 1 row.  We fill 6 fixed columns, but the cachedb core frees
+	 * expected_kv_no columns per row (free_raw_fetch), so the row MUST have
+	 * at least that many cdb_raw_entry slots -- a caller asking for > 6
+	 * output vars would otherwise make the core read+free past the row (heap
+	 * OOB).  Size to max(expected_kv_no, 6); the extra slots are zeroed so
+	 * they free harmlessly as NULL.  (Mirrors the raw_kv_keys ncols_per_row
+	 * fix.) */
+	int bi_ncols = (expected_kv_no > 6) ? expected_kv_no : 6;
 	rows = pkg_malloc(sizeof(cdb_raw_entry *));
 	if (!rows) {
 		nats_dl.kvStatus_Destroy(sts);
 		return -1;
 	}
-	rows[0] = pkg_malloc(6 * sizeof(cdb_raw_entry));
+	rows[0] = pkg_malloc(bi_ncols * sizeof(cdb_raw_entry));
 	if (!rows[0]) {
 		pkg_free(rows);
 		nats_dl.kvStatus_Destroy(sts);
 		return -1;
 	}
-	memset(rows[0], 0, 6 * sizeof(cdb_raw_entry));
+	memset(rows[0], 0, bi_ncols * sizeof(cdb_raw_entry));
 
 	/* col 0: bucket name */
 	bname = nats_dl.kvStatus_Bucket(sts);

--- a/modules/cachedb_nats/cachedb_nats_watch.c
+++ b/modules/cachedb_nats/cachedb_nats_watch.c
@@ -484,7 +484,22 @@ static void _watcher_loop(void)
 		/* ---- Event loop ----
 		 * Process live KV updates until a reconnect or disconnect
 		 * invalidates the current watcher and KV handle. */
+		unsigned orphan_poll = 0;
 		while (atomic_load(&_watcher_running)) {
+			/* Orphan watchdog (dedicated_watcher_proc=1): if the parent
+			 * died and PR_SET_PDEATHSIG didn't fire, the kernel reparents us
+			 * to PID 1.  The NATS_TIMEOUT arm below also checks this, but a
+			 * broker delivering a steady update stream never times out -- so
+			 * poll here too, rate-limited (every 256 iterations) to keep
+			 * getppid() off the per-event hot path.  No-op for the rank-1
+			 * pthread variant (getppid() returns the master forever). */
+			if ((++orphan_poll & 0xFF) == 0 && getppid() == 1) {
+				LM_NOTICE("watcher: parent gone (reparented to init); "
+					"exiting\n");
+				atomic_store(&_watcher_running, 0);
+				break;
+			}
+
 			/* Check for reconnect -- epoch changed means connection
 			 * was lost and restored; our KV handle and watcher are
 			 * stale. Break out for a full rebuild. */

--- a/modules/cachedb_nats/cachedb_nats_watch.c
+++ b/modules/cachedb_nats/cachedb_nats_watch.c
@@ -242,6 +242,7 @@ static void _raise_kv_change_event(kvEntry *entry, kvOperation op)
 	const char *val = NULL;
 	int key_len, val_len = 0;
 	unsigned long alloc_size;
+	kvOperation eff_op = op;
 
 	if (evi_kv_change_id == EVI_ERROR)
 		return;
@@ -257,6 +258,13 @@ static void _raise_kv_change_event(kvEntry *entry, kvOperation op)
 		val     = nats_dl.kvEntry_ValueString(entry);
 		val_len = nats_dl.kvEntry_ValueLen(entry);
 		if (!val) val_len = 0;
+		/* A server-side MaxAge/TTL expiry (and our own delete markers)
+		 * surface via cnats (<=3.12) as an empty-value Put.  The index
+		 * treats that as a REMOVE (_watch_index_action); raise it to EVI
+		 * subscribers as a delete too, so presence-tracking scripts see the
+		 * key vanish rather than a phantom "put" for a now-absent key. */
+		if (val_len == 0)
+			eff_op = kvOp_Delete;
 	}
 
 	/* Single shm allocation: struct + key\0 + [value\0] */
@@ -270,7 +278,7 @@ static void _raise_kv_change_event(kvEntry *entry, kvOperation op)
 		return;
 	}
 
-	ev->op       = op;
+	ev->op       = eff_op;
 	ev->revision = (int)nats_dl.kvEntry_Revision(entry);
 	ev->key_len  = key_len;
 	ev->val_len  = val_len;
@@ -296,13 +304,19 @@ static void _raise_kv_change_event(kvEntry *entry, kvOperation op)
 	/* EVI not available at build time -- log the change instead */
 	const char *key = nats_dl.kvEntry_Key(entry);
 	const char *op_name;
+	kvOperation eff_op = op;
 
 	if (!key) {
 		LM_WARN("kv-change: entry has NULL key, skipping log\n");
 		return;
 	}
 
-	switch (op) {
+	/* Same empty-value-Put -> delete classification as the EVI path, so the
+	 * log agrees with the index's REMOVE semantics on a TTL tombstone. */
+	if (op == kvOp_Put && nats_dl.kvEntry_ValueLen(entry) == 0)
+		eff_op = kvOp_Delete;
+
+	switch (eff_op) {
 		case kvOp_Put:    op_name = "put";    break;
 		case kvOp_Delete: op_name = "delete"; break;
 		default:          op_name = "purge";  break;

--- a/modules/cachedb_nats/tests/test_counter_parse_strict.c
+++ b/modules/cachedb_nats/tests/test_counter_parse_strict.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: the counter ops (cachedb_nats_dbase.c) parsed the stored KV
+ * value with bare strtoll(vs, NULL, 10).  A non-numeric value like "abc"
+ * returns 0 with no errno, so the range check passed and the counter was
+ * silently RESET to `delta` (increment path) or reported as 0 (get path)
+ * instead of being rejected -- a corrupt/hostile broker value bypassing the
+ * intended fail-closed behaviour.
+ *
+ * Fix: nats_counter_parse() strictly requires a pure (optionally signed,
+ * whitespace-padded) base-10 integer in the 32-bit range; anything else
+ * (no digits, trailing garbage, out of range) is rejected.  A NULL value
+ * (counter absent) parses as 0 -- the create path.
+ *
+ * Models nats_counter_parse():
+ *   -DSIMULATE_LOOSE_PARSE -> bare strtoll -> "abc" parses to 0 -> FAILS.
+ *   (default)              -> strict parse -> "abc" rejected -> ALL PASS.
+ * plus a source-wiring assertion.
+ *
+ * Build: gcc -g -O0 -fsanitize=address -Wall -o test_counter_parse_strict \
+ *        test_counter_parse_strict.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <errno.h>
+
+static int g_fails;
+#define ASSERT(cond, msg) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", msg);            } \
+} while (0)
+
+static int file_contains(const char *path, const char *needle)
+{
+	FILE *f = fopen(path, "r");
+	char line[4096];
+	int hit = 0;
+	if (!f) return 0;
+	while (fgets(line, sizeof(line), f))
+		if (strstr(line, needle)) { hit = 1; break; }
+	fclose(f);
+	return hit;
+}
+
+/* Model of nats_counter_parse(). Returns 0 (+*out) on a valid 32-bit int,
+ * -1 on non-numeric/trailing-garbage/out-of-range.  NULL -> 0 (create path). */
+static int counter_parse(const char *s, long long *out)
+{
+	if (!s) { *out = 0; return 0; }
+#ifdef SIMULATE_LOOSE_PARSE
+	{
+		long long v;
+		errno = 0;
+		v = strtoll(s, NULL, 10);          /* "abc" -> 0, no error */
+		if (errno == ERANGE || v < INT_MIN || v > INT_MAX) return -1;
+		*out = v;
+		return 0;
+	}
+#else
+	{
+		char *endp;
+		long long v;
+		errno = 0;
+		v = strtoll(s, &endp, 10);
+		if (endp == s) return -1;                          /* no digits */
+		while (*endp == ' ' || *endp == '\t' ||
+		       *endp == '\n' || *endp == '\r') endp++;
+		if (*endp != '\0') return -1;                      /* trailing garbage */
+		if (errno == ERANGE || v < INT_MIN || v > INT_MAX) return -1;
+		*out = v;
+		return 0;
+	}
+#endif
+}
+
+int main(void)
+{
+	long long v;
+
+	ASSERT(counter_parse("42", &v) == 0 && v == 42, "a plain integer parses");
+	ASSERT(counter_parse("  -7 ", &v) == 0 && v == -7,
+		"a signed, whitespace-padded integer parses");
+	ASSERT(counter_parse(NULL, &v) == 0 && v == 0,
+		"an absent counter (NULL) parses as 0 (create path)");
+
+	ASSERT(counter_parse("abc", &v) == -1,
+		"a non-numeric value is REJECTED (not silently reset to 0)");
+	ASSERT(counter_parse("12abc", &v) == -1,
+		"trailing garbage after a number is rejected");
+	ASSERT(counter_parse("", &v) == -1,
+		"an empty (non-NULL) value is rejected");
+
+	/* 2^40 is a valid int64 but out of the 32-bit counter range. */
+	ASSERT(counter_parse("1099511627776", &v) == -1,
+		"a value beyond 32-bit range is rejected");
+
+	/* ---- production wiring ---------------------------------------- */
+	{
+		const char *src = "../cachedb_nats_dbase.c";
+		ASSERT(file_contains(src, "nats_counter_parse"),
+			"the counter ops route the stored value through nats_counter_parse");
+		ASSERT(file_contains(src, "endp == s"),
+			"nats_counter_parse rejects a value with no digits");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}

--- a/modules/cachedb_nats/tests/test_counter_value_uaf.c
+++ b/modules/cachedb_nats/tests/test_counter_value_uaf.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: the cachedb_nats counter read-modify-write (cachedb_nats_dbase.c)
+ * logged the raw broker value pointer returned by kvEntry_ValueString() AFTER
+ * kvEntry_Destroy() had already freed the entry -- a use-after-free READ on the
+ * "stored value out of 32-bit range" error path.  kvEntry_ValueString returns a
+ * pointer INTO the entry's own buffer, so the "%s" in LM_ERR reads freed heap
+ * (at best logs garbage / adjacent heap, at worst faults on an unmapped page).
+ *
+ * Fix: snapshot the value text into a stack buffer (cur_txt) BEFORE destroying
+ * the entry, and log the snapshot.
+ *
+ * This models the read+destroy+log step:
+ *   -DSIMULATE_UAF_BUG -> log the freed pointer -> ASan reports
+ *                         heap-use-after-free (proves the test catches the bug).
+ *   (default)          -> log the pre-destroy snapshot -> ASan-clean.
+ * plus a source-wiring assertion that the real counter path snapshots first.
+ *
+ * Build:
+ *   gcc -g -O0 -fsanitize=address -Wall -o test_counter_value_uaf \
+ *       test_counter_value_uaf.c
+ *   # buggy arm (must trip ASan):
+ *   gcc -g -O0 -fsanitize=address -DSIMULATE_UAF_BUG -o /tmp/bug \
+ *       test_counter_value_uaf.c && /tmp/bug
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fails;
+#define ASSERT(cond, msg) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", msg);            } \
+} while (0)
+
+static int file_contains(const char *path, const char *needle)
+{
+	FILE *f = fopen(path, "r");
+	char line[4096];
+	int hit = 0;
+	if (!f) return 0;
+	while (fgets(line, sizeof(line), f))
+		if (strstr(line, needle)) { hit = 1; break; }
+	fclose(f);
+	return hit;
+}
+
+/* Stand-in for libnats' kvEntry: the value bytes live INSIDE the heap block
+ * the entry owns, exactly like cnats -- so a pointer from value_string()
+ * dangles the moment destroy() frees the entry. */
+typedef struct { char *value; } fake_entry;
+
+static fake_entry *entry_get(const char *v)
+{
+	fake_entry *e = malloc(sizeof(*e));
+	e->value = strdup(v);
+	return e;
+}
+static const char *entry_value_string(fake_entry *e) { return e->value; }
+static void entry_destroy(fake_entry *e) { free(e->value); free(e); }
+
+/* Model of the counter error-path: read the value pointer, destroy the entry,
+ * then emit a diagnostic string (standing in for LM_ERR's "%s"). */
+static void counter_error_log(fake_entry *e, char *log_out, size_t log_cap)
+{
+	const char *vs = entry_value_string(e);
+#ifdef SIMULATE_UAF_BUG
+	entry_destroy(e);                          /* free BEFORE using vs */
+	snprintf(log_out, log_cap, "%s", vs);      /* <-- use-after-free read */
+#else
+	char cur_txt[64];
+	snprintf(cur_txt, sizeof(cur_txt), "%s", vs ? vs : "(null)"); /* snapshot */
+	entry_destroy(e);
+	snprintf(log_out, log_cap, "%s", cur_txt); /* logs the snapshot, not vs */
+#endif
+}
+
+int main(void)
+{
+	char log[64];
+
+	/* An out-of-range broker value drives the error-log path. */
+	fake_entry *e = entry_get("999999999999999999999999");
+	counter_error_log(e, log, sizeof(log));
+	ASSERT(strcmp(log, "999999999999999999999999") == 0,
+		"error log reports the stored value from a pre-destroy snapshot "
+		"(ASan-clean; the buggy -DSIMULATE_UAF_BUG arm reads freed heap)");
+
+	/* ---- production wiring ---------------------------------------- */
+	{
+		const char *src = "../cachedb_nats_dbase.c";
+		ASSERT(file_contains(src, "cur_txt"),
+			"counter op snapshots the value text into cur_txt before destroy");
+		ASSERT(file_contains(src, "out of 32-bit range"),
+			"counter op still guards the out-of-range case");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}

--- a/modules/cachedb_nats/tests/test_counter_value_uaf.c
+++ b/modules/cachedb_nats/tests/test_counter_value_uaf.c
@@ -95,8 +95,8 @@ int main(void)
 		const char *src = "../cachedb_nats_dbase.c";
 		ASSERT(file_contains(src, "cur_txt"),
 			"counter op snapshots the value text into cur_txt before destroy");
-		ASSERT(file_contains(src, "out of 32-bit range"),
-			"counter op still guards the out-of-range case");
+		ASSERT(file_contains(src, "nats_counter_parse"),
+			"counter op still guards the value (via nats_counter_parse)");
 	}
 
 	fprintf(stderr, "\n=== %s (fails=%d) ===\n",

--- a/modules/cachedb_nats/tests/test_raw_query_cols.c
+++ b/modules/cachedb_nats/tests/test_raw_query_cols.c
@@ -46,6 +46,10 @@ typedef struct { int type; char *val; } col_t;
 
 static int ncols(int expected_kv_no) { return expected_kv_no >= 1 ? expected_kv_no : 1; }
 
+/* raw_kv_bucket_info fills 6 fixed columns but the core still frees
+ * expected_kv_no per row, so the row must have max(expected_kv_no, 6). */
+static int bi_ncols(int expected_kv_no) { return expected_kv_no > 6 ? expected_kv_no : 6; }
+
 /* build one row of `nc` zeroed columns, fill column 0 with the key */
 static col_t *build_row(int nc, const char *key)
 {
@@ -94,6 +98,34 @@ int main(void)
 			"row allocation uses expected_kv_no columns");
 		ASSERT(file_contains(n, "memset(rows[i], 0, ncols_per_row"),
 			"extra columns are zero-initialised (free as NULL)");
+	}
+
+	/* ---- raw_kv_bucket_info: same OOB class -------------------- */
+	/* bucket_info returns 1 row of 6 fixed columns, but the core frees
+	 * expected_kv_no columns per row.  Asking for > 6 output vars made the
+	 * core read+free past the 6-column row (heap OOB read + bad free).  The
+	 * fix sizes the row max(expected_kv_no, 6) and zeroes the extras. */
+	{
+		ASSERT(bi_ncols(6) == 6, "expected_kv_no<=6 -> 6 columns");
+		ASSERT(bi_ncols(7) == 7, "expected_kv_no=7 -> 7 columns");
+		ASSERT(bi_ncols(1) == 6, "expected_kv_no=1 still keeps the 6 filled columns");
+
+		/* model: core frees `expected` cols over a max(expected,6) row.
+		 * With the fix all are in-bounds; the old fixed-6 alloc would OOB
+		 * when expected=7 (ASan would trip). */
+		int expected = 7;
+		col_t *row = build_row(bi_ncols(expected), "bucket-name");   /* 7 cols */
+		ASSERT(row != NULL, "bucket_info row sized to max(expected_kv_no, 6)");
+		core_free_row(row, expected);
+		ASSERT(1, "core free over expected_kv_no cols is in-bounds (ASan-clean)");
+
+		const char *n = "../cachedb_nats_native.c";
+		ASSERT(file_contains(n, "bi_ncols"),
+			"raw_kv_bucket_info sizes the row by bi_ncols");
+		ASSERT(file_contains(n, "bi_ncols * sizeof(cdb_raw_entry)"),
+			"bucket_info row allocation uses max(expected_kv_no, 6) columns");
+		ASSERT(file_contains(n, "memset(rows[0], 0, bi_ncols"),
+			"bucket_info extra columns are zero-initialised (free as NULL)");
 	}
 
 	if (g_fails == 0) fprintf(stderr, "\n=== ALL PASS (fails=0) ===\n");

--- a/modules/cachedb_nats/tests/test_str_to_buf_nul.c
+++ b/modules/cachedb_nats/tests/test_str_to_buf_nul.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: nats_str_to_buf (lib/nats/nats_str.h) is the shared str->C-string
+ * chokepoint for the generic cachedb_nats write paths (nats_cache_set,
+ * w_nats_kv_put, nats_cache_map_set).  It guarded negative and oversize lengths
+ * but NOT an embedded NUL: it copied the NUL-bearing value and NUL-terminated,
+ * and the downstream kvStore_PutString (a C-string API) then silently truncated
+ * the stored value at the embedded NUL -- so set("a\0b") stored "a" and a later
+ * get returned "a" (silent data loss).  The usrloc row path is unaffected (it
+ * uses length-aware natsMsg_Create), and keys never legitimately contain NUL.
+ *
+ * Fix: nats_str_to_buf rejects a value containing an embedded NUL (memchr),
+ * consistent with the module's fail-closed reject-at-write hygiene.
+ *
+ * Models the accept/reject decision:
+ *   -DSIMULATE_NO_NUL_CHECK -> no NUL guard -> embedded-NUL value accepted
+ *                              (and would truncate downstream) -> assertion FAILS.
+ *   (default)               -> embedded NUL rejected -> ALL PASS.
+ * plus a source-wiring assertion.
+ *
+ * Build: gcc -g -O0 -Wall -o test_str_to_buf_nul test_str_to_buf_nul.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fails;
+#define ASSERT(cond, msg) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", msg);            } \
+} while (0)
+
+static int file_contains(const char *path, const char *needle)
+{
+	FILE *f = fopen(path, "r");
+	char line[4096];
+	int hit = 0;
+	if (!f) return 0;
+	while (fgets(line, sizeof(line), f))
+		if (strstr(line, needle)) { hit = 1; break; }
+	fclose(f);
+	return hit;
+}
+
+/* Model of nats_str_to_buf's accept/reject decision (s may contain embedded
+ * NULs; len is the authoritative byte count). Returns 0 on success, -1 reject. */
+static int str_to_buf(const char *s, int len, char *buf, int bufsize)
+{
+	if (len < 0) return -1;
+	if (!s || len <= 0) { buf[0] = '\0'; return 0; }
+	if (len >= bufsize) return -1;
+#ifndef SIMULATE_NO_NUL_CHECK
+	if (memchr(s, '\0', (size_t)len)) return -1;   /* embedded NUL -> reject */
+#endif
+	memcpy(buf, s, len);
+	buf[len] = '\0';
+	return 0;
+}
+
+int main(void)
+{
+	char buf[64];
+
+	ASSERT(str_to_buf("abc", 3, buf, sizeof(buf)) == 0 && strcmp(buf, "abc") == 0,
+		"a clean value is accepted verbatim");
+
+	/* "a\0b" -- 3 bytes with an embedded NUL. */
+	ASSERT(str_to_buf("a\0b", 3, buf, sizeof(buf)) == -1,
+		"a value with an embedded NUL is REJECTED (not silently truncated)");
+
+	ASSERT(str_to_buf(NULL, 0, buf, sizeof(buf)) == 0 && buf[0] == '\0',
+		"a NULL/empty value yields an empty string");
+	ASSERT(str_to_buf("x", -1, buf, sizeof(buf)) == -1,
+		"a negative length is rejected");
+
+	/* ---- production wiring ---------------------------------------- */
+	{
+		const char *src = "../../../lib/nats/nats_str.h";
+		ASSERT(file_contains(src, "memchr(s->s, '\\0'"),
+			"nats_str_to_buf rejects an embedded NUL via memchr");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}

--- a/modules/cachedb_nats/tests/test_update_nul_poison.c
+++ b/modules/cachedb_nats/tests/test_update_nul_poison.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: the usrloc update/merge CAS path (cachedb_nats_json.c) fetched a
+ * stored doc via kvEntry_ValueString + kvEntry_ValueLen (data_len), copied
+ * data_len bytes, but then _update_apply_and_cas recomputed the length with
+ * strlen(json_buf) -- discarding data_len.  A stored doc containing an embedded
+ * NUL (a poison value from a hostile/foreign broker writer, or from the generic
+ * *String set path) is truncated by strlen at the NUL: the single-pass merge
+ * parses only the prefix, appends its own closing brace, and CAS-writes back a
+ * structurally-valid but TRUNCATED document -- silently dropping every contact
+ * after the NUL.  The read/query path already rejects a raw NUL via
+ * _json_parse_guard; the update path did not.
+ *
+ * Fix: _update_fetch_or_seed fails closed when the fetched doc contains an
+ * embedded NUL (strlen(json_buf) != data_len), so a poison doc is never merged
+ * or laundered into a valid-looking short doc.
+ *
+ * Models the fetch length decision:
+ *   -DSIMULATE_STRLEN_BUG -> measure with strlen -> truncated length returned.
+ *   (default)             -> reject when strlen != data_len -> -1 (fail closed).
+ * plus a source-wiring assertion.
+ *
+ * Build:
+ *   gcc -g -O0 -fsanitize=address -Wall -o test_update_nul_poison \
+ *       test_update_nul_poison.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fails;
+#define ASSERT(cond, msg) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", msg);            } \
+} while (0)
+
+static int file_contains(const char *path, const char *needle)
+{
+	FILE *f = fopen(path, "r");
+	char line[4096];
+	int hit = 0;
+	if (!f) return 0;
+	while (fgets(line, sizeof(line), f))
+		if (strstr(line, needle)) { hit = 1; break; }
+	fclose(f);
+	return hit;
+}
+
+/* Model of the fetch step: @data/@data_len is the broker-supplied doc
+ * (data_len is the authoritative kvEntry_ValueLen).  Copies it NUL-terminated
+ * and decides the length the merge will operate on.  Returns that length, or
+ * -1 to reject (fail closed) a poison doc. */
+static int fetch_doc_len(const char *data, int data_len)
+{
+	char *json_buf = malloc(data_len + 1);
+	int rc;
+	memcpy(json_buf, data, data_len);
+	json_buf[data_len] = '\0';
+#ifdef SIMULATE_STRLEN_BUG
+	rc = (int)strlen(json_buf);          /* truncates at an embedded NUL */
+#else
+	if ((int)strlen(json_buf) != data_len)
+		rc = -1;                         /* embedded NUL -> fail closed */
+	else
+		rc = (int)strlen(json_buf);
+#endif
+	free(json_buf);
+	return rc;
+}
+
+int main(void)
+{
+	/* A clean doc: full length, accepted either way. */
+	{
+		const char clean[] = "{\"aor\":\"alice\"}";
+		ASSERT(fetch_doc_len(clean, (int)sizeof(clean) - 1)
+				== (int)sizeof(clean) - 1,
+			"clean doc: full length preserved");
+	}
+
+	/* A poison doc with an embedded NUL between two contacts.  data_len
+	 * spans the WHOLE doc; strlen would stop at the NUL and drop contact
+	 * "b".  The fix rejects it (fail closed). */
+	{
+		const char poison[] =
+			"{\"contacts\":{\"a\":1}\0,\"b\":2}";     /* NUL mid-doc */
+		int data_len = (int)sizeof(poison) - 1;        /* includes bytes after NUL */
+		int truncated = (int)strlen(poison);           /* prefix only */
+		ASSERT(truncated < data_len, "poison doc: strlen prefix < full data_len");
+		ASSERT(fetch_doc_len(poison, data_len) == -1,
+			"poison doc with embedded NUL is REJECTED (not truncated/merged)");
+	}
+
+	/* ---- production wiring ---------------------------------------- */
+	{
+		const char *src = "../cachedb_nats_json.c";
+		ASSERT(file_contains(src, "strlen(json_buf) != data_len"),
+			"_update_fetch_or_seed fails closed on strlen(json_buf) != data_len");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}

--- a/modules/cachedb_nats/tests/test_watch_evi_expire_op.c
+++ b/modules/cachedb_nats/tests/test_watch_evi_expire_op.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: the KV watcher's _raise_kv_change_event (cachedb_nats_watch.c)
+ * emitted the E_NATS_KV_CHANGE event with the RAW kvOperation.  A server-side
+ * MaxAge/TTL expiry (and the module's own delete markers) surface via cnats
+ * (<=3.12) as a kvOp_Put with an EMPTY value.  The in-SHM index correctly maps
+ * that empty-value Put to a REMOVE (_watch_index_action), but the EVI event was
+ * raised as operation="put" -- so a presence-tracking script saw a phantom
+ * "put" for a key that had actually vanished (index and EVI disagreeing on the
+ * same event).
+ *
+ * Fix: classify an empty-value Put as a delete for the raised event, matching
+ * the index's REMOVE semantics.
+ *
+ * Models the op-classification:
+ *   -DSIMULATE_RAW_OP_BUG -> emit the raw op -> empty-value Put stays "put".
+ *   (default)             -> empty-value Put becomes delete.
+ * plus a source-wiring assertion.
+ *
+ * Build: gcc -g -O0 -Wall -o test_watch_evi_expire_op test_watch_evi_expire_op.c
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int g_fails;
+#define ASSERT(cond, msg) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", msg);            } \
+} while (0)
+
+static int file_contains(const char *path, const char *needle)
+{
+	FILE *f = fopen(path, "r");
+	char line[4096];
+	int hit = 0;
+	if (!f) return 0;
+	while (fgets(line, sizeof(line), f))
+		if (strstr(line, needle)) { hit = 1; break; }
+	fclose(f);
+	return hit;
+}
+
+/* Mirror the cnats kvOperation values we care about. */
+enum { KVOP_PUT = 1, KVOP_DELETE = 2, KVOP_PURGE = 3 };
+
+/* Model of the effective op the EVI event should carry. */
+static int eff_evi_op(int op, int val_len)
+{
+#ifdef SIMULATE_RAW_OP_BUG
+	(void)val_len;
+	return op;                                  /* raw op: empty Put stays put */
+#else
+	if (op == KVOP_PUT && val_len == 0)
+		return KVOP_DELETE;                     /* MaxAge tombstone -> delete */
+	return op;
+#endif
+}
+
+int main(void)
+{
+	ASSERT(eff_evi_op(KVOP_PUT, 42) == KVOP_PUT,
+		"a real value Put stays a put");
+	ASSERT(eff_evi_op(KVOP_PUT, 0) == KVOP_DELETE,
+		"an empty-value Put (TTL expiry/tombstone) is raised as a delete");
+	ASSERT(eff_evi_op(KVOP_DELETE, 0) == KVOP_DELETE,
+		"an explicit delete stays a delete");
+	ASSERT(eff_evi_op(KVOP_PURGE, 0) == KVOP_PURGE,
+		"a purge stays a purge");
+
+	/* ---- production wiring ---------------------------------------- */
+	{
+		const char *src = "../cachedb_nats_watch.c";
+		ASSERT(file_contains(src, "eff_op") &&
+		       file_contains(src, "eff_op = kvOp_Delete"),
+			"_raise_kv_change_event remaps an empty-value Put to kvOp_Delete");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}

--- a/modules/nats_consumer/nats_consumer_proc.c
+++ b/modules/nats_consumer/nats_consumer_proc.c
@@ -446,6 +446,12 @@ static int _fetch_batch(proc_sub_state_t *ss, int budget_ms,
 			nats_dl.natsSubscription_Unsubscribe(ss->sub);
 			nats_dl.natsSubscription_Destroy(ss->sub);
 			ss->sub = NULL;
+			/* The sub is gone; any fetched-but-un-acked natsMsg still in
+			 * this handle's ref row now holds a dangling msg->sub.  Purge
+			 * before the recreate so a late ack can't deref a freed sub
+			 * (UAF).  The broker redelivers un-acked messages on the new
+			 * subscription. */
+			purge_msg_ref_row(ss->handle_idx);
 		}
 		ss->dirty = 1;
 		hstat_add(ss->h_ref, &ss->h_ref->fetch_errors, 1);
@@ -913,33 +919,14 @@ static void tear_down_retired_subs(void)
 		 * Reclaim the process-local msg-ref row for this handle.  After
 		 * the subscription is destroyed no more acks can arrive for it,
 		 * but messages that were pushed to the ring and not yet acked
-		 * still hold a live natsMsg* in g_msg_refs[handle_idx].slots[*].
-		 * Normally those are released + destroyed on the ack drain path
-		 * (release_msg_ref + nats_dl.natsMsg_Destroy); here we must walk
-		 * the row ourselves, destroy every in-use natsMsg, then free the
-		 * row's slots buffer (calloc'd in ensure_row) and zero the row.
-		 * handle_idx is monotonic and never reused, so leaving the row
-		 * populated would leak both the slots buffer and the libnats
-		 * messages for the lifetime of the process.
+		 * still hold a live natsMsg* in g_msg_refs[handle_idx].slots[*]
+		 * whose msg->sub now dangles.  purge_msg_ref_row destroys every
+		 * in-use natsMsg, frees the row's slots buffer (calloc'd in
+		 * ensure_row) and zeroes the row -- otherwise a later ack would
+		 * deref the freed subscription and both the slots buffer and the
+		 * libnats messages would leak for the process lifetime.
 		 */
-		if (ss->handle_idx < NATS_REGISTRY_MAX_HANDLES) {
-			msg_ref_row_t *row = &g_msg_refs[ss->handle_idx];
-			if (row->slots) {
-				uint32_t i;
-				for (i = 0; i < row->capacity; i++) {
-					msg_ref_slot_t *slot = &row->slots[i];
-					if (slot->in_use && slot->msg) {
-						nats_dl.natsMsg_Destroy(slot->msg);
-						slot->msg    = NULL;
-						slot->in_use = 0;
-					}
-				}
-				free(row->slots);
-			}
-			row->slots     = NULL;
-			row->capacity  = 0;
-			row->next_slot = 0;
-		}
+		purge_msg_ref_row(ss->handle_idx);
 
 		if (h) {
 			/* Publish the teardown completion so the reaper can
@@ -1117,6 +1104,12 @@ void nats_consumer_proc_main(int rank)
 					nats_dl.natsSubscription_Unsubscribe(ss->sub);
 					nats_dl.natsSubscription_Destroy(ss->sub);
 					ss->sub = NULL;
+					/* Old-connection subscription is dead; every fetched
+					 * natsMsg still held in this handle's ref row now has a
+					 * dangling msg->sub.  Purge before the rebuild so a late
+					 * ack can't deref the freed sub (UAF); JetStream
+					 * redelivers the un-acked messages on reconnect. */
+					purge_msg_ref_row(ss->handle_idx);
 				}
 				ss->dirty = 1;
 			}

--- a/modules/nats_consumer/nats_consumer_proc_internal.h
+++ b/modules/nats_consumer/nats_consumer_proc_internal.h
@@ -144,6 +144,11 @@ uint64_t store_msg_ref(uint16_t handle_idx, uint32_t ring_capacity,
 natsMsg *release_msg_ref(uint64_t token);
 /* Reclaim slots older than the orphan TTL; returns the reap count. */
 int reap_orphan_msg_refs(void);
+/* Destroy every outstanding natsMsg for a handle and free its ref row.
+ * MUST be called at every subscription-destroy site: a fetched natsMsg
+ * holds an unref'd msg->sub, so acking one after its sub is destroyed is a
+ * use-after-free. */
+void purge_msg_ref_row(uint16_t handle_idx);
 
 /* ── subscription config / lifecycle (nats_sub_config.c) ──────── */
 

--- a/modules/nats_consumer/nats_msg_ref.c
+++ b/modules/nats_consumer/nats_msg_ref.c
@@ -186,6 +186,42 @@ natsMsg *release_msg_ref(uint64_t token)
 }
 
 /*
+ * Purge every outstanding msg-ref for a handle: destroy each in-use
+ * natsMsg, free the row's slots buffer, and zero the row.  Called from
+ * EVERY subscription-destroy site (retire teardown, vanished/GC'd-consumer
+ * recreate, reconnect-epoch refresh).  A delivered/fetched natsMsg stores a
+ * raw msg->sub pointer with no refcount on the subscription; once the sub is
+ * natsSubscription_Destroy'd, acking any still-held msg would deref a freed
+ * subscription (use-after-free).  Destroying the messages here severs that
+ * dangling reference -- the broker redelivers any un-acked JetStream message
+ * on reconnect, so dropping our local copy is also the correct semantics.
+ * Runs in the consumer process's single-threaded main loop (no locking).
+ */
+void purge_msg_ref_row(uint16_t handle_idx)
+{
+	msg_ref_row_t *row;
+	uint32_t i;
+
+	if (handle_idx >= NATS_REGISTRY_MAX_HANDLES)
+		return;
+	row = &g_msg_refs[handle_idx];
+	if (row->slots) {
+		for (i = 0; i < row->capacity; i++) {
+			msg_ref_slot_t *slot = &row->slots[i];
+			if (slot->in_use && slot->msg) {
+				nats_dl.natsMsg_Destroy(slot->msg);
+				slot->msg    = NULL;
+				slot->in_use = 0;
+			}
+		}
+		free(row->slots);
+	}
+	row->slots     = NULL;
+	row->capacity  = 0;
+	row->next_slot = 0;
+}
+
+/*
  * Reclaim msg-ref slots that have been outstanding longer than
  * NATS_MSG_REF_ORPHAN_TTL_US -- the worker that owned them died before
  * acking.  Destroys the leaked natsMsg, frees the slot (bumping the

--- a/modules/nats_consumer/nats_persist.c
+++ b/modules/nats_consumer/nats_persist.c
@@ -795,6 +795,30 @@ static char *build_config_from_json(cJSON *obj)
 		if (!c->string)
 			continue;
 
+		/* Sanitize the KEY with the same reject applied to values below: the
+		 * key is spliced verbatim into the "key=value;key=value" bind-config
+		 * (the fallback append_kv at the bottom of the loop uses c->string
+		 * directly), so an unknown key from a tampered persist file like
+		 * "x;id=evil" would forge extra config fields.  A legitimate
+		 * serialiser only emits identifier-like keys. */
+		{
+			const unsigned char *k = (const unsigned char *)c->string;
+			size_t i;
+			int bad = 0;
+			for (i = 0; k[i]; i++) {
+				if (k[i] < 0x20 || k[i] == 0x7F ||
+						k[i] == ';' || k[i] == '=') {
+					LM_WARN("nats_persist: rejecting field with illegal "
+						"key byte 0x%02x at offset %zu\n",
+						k[i], i);
+					bad = 1;
+					break;
+				}
+			}
+			if (bad)
+				continue;
+		}
+
 		/* "type" is a derived serialized field -- skip, since the parser
 		 * infers durable vs ephemeral from the presence of either key. */
 		if (strcmp(c->string, "type") == 0)

--- a/modules/nats_consumer/nats_rpc_async.c
+++ b/modules/nats_consumer/nats_rpc_async.c
@@ -1194,6 +1194,17 @@ static int resume_nats_request_slot(int fd, struct sip_msg *msg,
 		return disc ? -2 : -1;
 	}
 
+	if (state_obs == NATS_RPC_SLOT_DELIVERING) {
+		/* The consumer has pinned our claim and is writing the reply right
+		 * now.  Not ready yet -- and we must NOT abandon+free the slot under
+		 * the pin (that would break the consumer's exclusive DELIVERING ->
+		 * DELIVERED transition).  Keep polling even past the deadline: the
+		 * transition is a few instructions on the consumer thread, so the
+		 * next tick delivers an at-the-wire reply rather than dropping it. */
+		async_status = ASYNC_CONTINUE;
+		return 0;
+	}
+
 	/* state == INFLIGHT.  Check the per-call deadline so we
 	 * surface -1 even though the async core has no built-in
 	 * timeout for raw FDs.  Otherwise re-arm and keep polling. */
@@ -1202,7 +1213,15 @@ static int resume_nats_request_slot(int fd, struct sip_msg *msg,
 		int      cur_conn  = nats_pool_is_connected();
 		int      disc = !cur_conn || cur_epoch != s->epoch_at_start;
 
-		(void)nats_rpc_slot_abandon(s);
+		/* Claim the timeout only if we actually WIN the INFLIGHT ->
+		 * ABANDONED CAS.  If abandon() reports any other state the consumer
+		 * beat us and a reply is landing (DELIVERING) or landed (DELIVERED):
+		 * do NOT free -- keep polling so the reply is delivered on the next
+		 * tick instead of being lost exactly at the deadline. */
+		if (nats_rpc_slot_abandon(s) != NATS_RPC_SLOT_ABANDONED) {
+			async_status = ASYNC_CONTINUE;
+			return 0;
+		}
 		async_status = ASYNC_DONE_CLOSE_FD;
 		nats_rpc_slot_free(s);
 		pkg_free(w);

--- a/modules/nats_consumer/nats_rpc_consumer.c
+++ b/modules/nats_consumer/nats_rpc_consumer.c
@@ -152,15 +152,36 @@ static void on_inbox_reply(natsConnection *nc, natsSubscription *sub,
 		}
 	}
 
-	/* Refuse to overwrite if the worker already ABANDONED or
-	 * the slot somehow transitioned to a non-INFLIGHT state.
-	 * The slot's state field is the source of truth. */
+	/* Pin the claim BEFORE writing reply_* or re-validating the generation.
+	 * CAS INFLIGHT -> DELIVERING: if it fails, the worker already ABANDONED
+	 * (or the slot is otherwise non-INFLIGHT) -- drop.  While the slot is
+	 * DELIVERING the worker resume treats it as not-ready and never
+	 * abandons+frees it (resume_nats_request_slot), so no reclaim -- hence no
+	 * generation change -- can happen under us.  This makes "confirm this is
+	 * still our claim" and "publish the reply" atomic w.r.t. the worker,
+	 * closing the slot-reuse misdelivery window that existed when the
+	 * generation re-check was a separate step after an INFLIGHT -> DELIVERED
+	 * CAS (a worker that re-claimed the slot could observe DELIVERED with the
+	 * old reply in the gap before the rollback). */
 	{
-		int cur = atomic_load_explicit(&s->state, memory_order_acquire);
-		if (cur != NATS_RPC_SLOT_INFLIGHT) {
+		int expected = NATS_RPC_SLOT_INFLIGHT;
+		if (!atomic_compare_exchange_strong_explicit(
+				&s->state, &expected, NATS_RPC_SLOT_DELIVERING,
+				memory_order_acq_rel, memory_order_relaxed)) {
 			nats_dl.natsMsg_Destroy(msg);
 			return;
 		}
+	}
+
+	/* Now pinned.  Re-validate the generation: if the slot was freed and
+	 * re-claimed before our pin, we pinned a DIFFERENT (newer) claim -- roll
+	 * back to INFLIGHT so the new claimant is undisturbed, and drop this stale
+	 * reply.  Only we transition out of DELIVERING, so a plain store is safe. */
+	if (atomic_load_explicit(&s->generation, memory_order_relaxed) != gen) {
+		atomic_store_explicit(&s->state, NATS_RPC_SLOT_INFLIGHT,
+			memory_order_release);
+		nats_dl.natsMsg_Destroy(msg);
+		return;
 	}
 
 	/* Copy subject (bounded). */
@@ -200,35 +221,13 @@ static void on_inbox_reply(natsConnection *nc, natsSubscription *sub,
 		s->reply_headers_truncated = (uint8_t)(trunc ? 1 : 0);
 	}
 
-	/* Publish the slot transition.  Use CAS from INFLIGHT to DELIVERED:
-	 * the worker may have ABANDONED + freed the slot between the
-	 * acquire-load above and here, and another caller could have
-	 * already CLAIMed it.  Blind-storing DELIVERED in that case would
-	 * clobber the new claimer's state and hand them a stale reply.
-	 * Release ordering on success ensures the worker observes the
-	 * reply_* writes above on its next timerfd tick. */
-	{
-		int expected = NATS_RPC_SLOT_INFLIGHT;
-		if (atomic_compare_exchange_strong_explicit(
-				&s->state, &expected, NATS_RPC_SLOT_DELIVERED,
-				memory_order_release, memory_order_relaxed)) {
-			/* Re-verify the generation did not advance between the
-			 * guard above and this CAS.  If the slot was freed and
-			 * re-claimed in that window, we just attached this (old)
-			 * reply to a different request that happens to also be
-			 * INFLIGHT.  Roll the state back to ABANDONED so the new
-			 * claimant times out cleanly instead of reading another
-			 * request's reply payload. */
-			if (atomic_load_explicit(&s->generation,
-					memory_order_relaxed) != gen) {
-				int d = NATS_RPC_SLOT_DELIVERED;
-				(void)atomic_compare_exchange_strong_explicit(
-					&s->state, &d, NATS_RPC_SLOT_ABANDONED,
-					memory_order_release,
-					memory_order_relaxed);
-			}
-		}
-	}
+	/* Publish: DELIVERING -> DELIVERED with release ordering so the worker's
+	 * next timerfd tick observes the reply_* writes above.  The slot is pinned
+	 * (only we transition out of DELIVERING) and the generation was validated
+	 * while pinned, so a plain release store is correct and race-free -- the
+	 * worker consumes this reply for exactly the claim it was minted for. */
+	atomic_store_explicit(&s->state, NATS_RPC_SLOT_DELIVERED,
+		memory_order_release);
 
 	nats_dl.natsMsg_Destroy(msg);
 }

--- a/modules/nats_consumer/nats_rpc_slot.h
+++ b/modules/nats_consumer/nats_rpc_slot.h
@@ -90,6 +90,16 @@ enum {
 	NATS_RPC_SLOT_INFLIGHT  = 2,
 	NATS_RPC_SLOT_DELIVERED = 3,
 	NATS_RPC_SLOT_ABANDONED = 4,
+	/* DELIVERING pins the claim for the duration of a reply write: the
+	 * consumer CAS's INFLIGHT -> DELIVERING BEFORE writing reply_* or
+	 * re-validating the generation, and only then stores DELIVERED.  While a
+	 * slot is DELIVERING the worker resume treats it as not-ready and never
+	 * abandons+frees it, so the generation cannot change under the consumer.
+	 * This makes "confirm this is still our claim" and "publish the reply"
+	 * atomic w.r.t. the worker, closing the slot-reuse reply-misdelivery
+	 * window that existed when the generation re-check was a separate step
+	 * after the INFLIGHT -> DELIVERED CAS. */
+	NATS_RPC_SLOT_DELIVERING = 5,
 };
 
 /*

--- a/modules/nats_consumer/nats_sub_config.c
+++ b/modules/nats_consumer/nats_sub_config.c
@@ -426,6 +426,20 @@ static int build_consumer_config(nats_handle_t *h, proc_sub_state_t *ss,
 	domain_c     = nats_str_to_cstr(&h->js_domain);
 	api_prefix_c = nats_str_to_cstr(&h->api_prefix);
 
+	/* `stream` is required and parser-guaranteed non-empty, so a NULL cstr
+	 * here means nats_str_to_cstr hit OOM (not an empty source).  Fail the
+	 * build rather than hand nats.c a NULL Stream downstream (so.Stream /
+	 * js_AddConsumer would then dereference or error on it).  Likewise a
+	 * durable consumer needs its durable name. */
+	if (!stream_c ||
+	    (h->type == NATS_CONSUMER_DURABLE && !durable_c)) {
+		LM_ERR("nats_sub_config: OOM building required consumer cstr "
+			"(stream%s)\n",
+			(h->type == NATS_CONSUMER_DURABLE && !durable_c)
+				? "/durable" : "");
+		goto fail;
+	}
+
 	/* Render sample_freq as a string -- nats.c expects a C string here,
 	 * e.g. "25" for 25% sampling.  Only set when the script supplied
 	 * a non-zero value; zero means "disabled / don't sample".

--- a/modules/nats_consumer/tests/.gitignore
+++ b/modules/nats_consumer/tests/.gitignore
@@ -47,6 +47,7 @@ test_ring_wake_one
 test_ring_xproc_wakeup
 test_rpc_inbox_auth
 test_rpc_ipc_generation
+test_rpc_reply_pin
 test_rpc_subject_validation
 test_rpc_tunables
 test_slot_prefix_copy

--- a/modules/nats_consumer/tests/Makefile
+++ b/modules/nats_consumer/tests/Makefile
@@ -16,6 +16,7 @@ PERSIST_SRCS := test_persist.c $(SHIM) cjson_test_shim.c \
                ../nats_persist.c ../nats_handle_parse.c ../nats_handle_registry.c
 SUBJECT_SRCS := test_rpc_subject.c $(SHIM) ../nats_rpc_subject.c ../nats_rpc_slot.c
 IPCGEN_SRCS  := test_rpc_ipc_generation.c $(SHIM) ../nats_rpc_slot.c
+REPLYPIN_SRCS := test_rpc_reply_pin.c $(SHIM) ../nats_rpc_slot.c
 INBOXAUTH_SRCS := test_rpc_inbox_auth.c $(SHIM) ../nats_rpc_subject.c ../nats_rpc_slot.c
 LOOKUPREF_SRCS := test_registry_lookup_ref.c $(SHIM) ../nats_handle_registry.c
 IDXRECYCLE_SRCS := test_registry_index_recycle.c $(SHIM) ../nats_handle_registry.c
@@ -34,7 +35,7 @@ TESTS_TSAN_SAFE = test_registry test_parser test_ring test_ack_token \
                   test_rpc_subject test_fetch_async_timerfd \
                   test_persist_cross_process test_msg_ref_teardown \
                   test_ring_bounded_spin test_registry_ring_ref_safety \
-                  test_ring_xproc_wakeup test_rpc_ipc_generation \
+                  test_ring_xproc_wakeup test_rpc_ipc_generation test_rpc_reply_pin \
                   test_rpc_inbox_auth test_registry_lookup_ref \
                   test_consumer_proc_boot_retry test_rpc_subject_validation \
                   test_registry_index_recycle test_ring_push_bounded_spin \
@@ -59,7 +60,7 @@ all: test_registry test_parser test_ring test_ack_token test_persist \
      test_retired_no_sub_reap test_sub_identity_match \
      test_fetch_budget test_ring_wake_one \
      test_bind_bounds test_rpc_tunables \
-     test_slot_prefix_copy test_replay_bias test_backpressure_stats test_consumer_stats_mi test_poison_term test_dead_inbox_retry test_mpsc test_ensure_backoff test_proc_tu_split test_request_fastfail
+     test_slot_prefix_copy test_replay_bias test_backpressure_stats test_consumer_stats_mi test_poison_term test_dead_inbox_retry test_mpsc test_ensure_backoff test_proc_tu_split test_request_fastfail test_rpc_reply_pin
 
 test_registry: $(REG_SRCS) test_shim.h ../nats_handle_registry.h
 	$(CC) $(CFLAGS) -o $@ $(REG_SRCS) $(LDFLAGS)
@@ -118,6 +119,13 @@ test_rpc_subject: $(SUBJECT_SRCS) test_shim.h ../nats_rpc_subject.h ../nats_rpc_
 # claim's request.  Built with a 1-slot pool to force the reuse.
 test_rpc_ipc_generation: $(IPCGEN_SRCS) test_shim.h ../nats_rpc_slot.h ../nats_rpc_ipc.h
 	$(CC) $(CFLAGS) -DNATS_RPC_SLOT_COUNT=1 -o $@ $(IPCGEN_SRCS) $(LDFLAGS)
+
+# Slot-reuse reply-misdelivery: on_inbox_reply pins the claim (INFLIGHT ->
+# DELIVERING) before writing reply_* + re-checking generation, so a worker that
+# re-claimed the slot can never consume another request's reply.  1-slot pool
+# forces the reuse.
+test_rpc_reply_pin: $(REPLYPIN_SRCS) test_shim.h ../nats_rpc_slot.h
+	$(CC) $(CFLAGS) -DNATS_RPC_SLOT_COUNT=1 -o $@ $(REPLYPIN_SRCS) $(LDFLAGS)
 
 # Reply-inbox authentication: a forged reply that guesses slot+gen but
 # not the per-call corr_id must be rejected by on_inbox_reply's check.
@@ -297,6 +305,7 @@ check: all
 	./test_registry_ring_ref_safety
 	./test_ring_xproc_wakeup
 	./test_rpc_ipc_generation
+	./test_rpc_reply_pin
 	./test_rpc_inbox_auth
 	./test_registry_lookup_ref
 	./test_consumer_proc_boot_retry

--- a/modules/nats_consumer/tests/test_msg_ref_teardown.c
+++ b/modules/nats_consumer/tests/test_msg_ref_teardown.c
@@ -245,6 +245,16 @@ static char *extract_func_body(const char *path, const char *funcname)
 	size_t flen = strlen(funcname);
 	while ((p = strstr(p, funcname)) != NULL) {
 		char *q = p + flen;
+		/* Require a word boundary before the name so a search for
+		 * "_fetch_batch" does not match inside "eff_fetch_batch". */
+		if (p != buf) {
+			char c = p[-1];
+			if (c == '_' || (c >= 'a' && c <= 'z') ||
+			    (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+				p += flen;
+				continue;
+			}
+		}
 		while (*q == ' ' || *q == '\t') q++;
 		if (*q != '(') { p += flen; continue; }
 		char *brace = q;
@@ -266,26 +276,52 @@ static char *extract_func_body(const char *path, const char *funcname)
 
 static void test_source_structure(void)
 {
-	const char *src = "../nats_consumer_proc.c";
-	char *td = extract_func_body(src, "tear_down_retired_subs");
+	/* The purge walk lives in a shared helper purge_msg_ref_row()
+	 * (nats_msg_ref.c) so EVERY subscription-destroy site reuses the same
+	 * teardown -- destroying outstanding natsMsg* whose msg->sub is about
+	 * to be freed.  A site that destroys the sub but skips the purge leaves
+	 * a dangling msg->sub for a later ack to deref (UAF). */
+	char *purge = extract_func_body("../nats_msg_ref.c", "purge_msg_ref_row");
 
-	ASSERT(td != NULL, "found tear_down_retired_subs body");
-	if (!td)
-		return;
+	ASSERT(purge != NULL, "found purge_msg_ref_row body in nats_msg_ref.c");
+	if (purge) {
+		ASSERT(strstr(purge, "g_msg_refs[") != NULL,
+			"purge walks the handle's msg-ref row g_msg_refs[handle_idx]");
+		ASSERT(strstr(purge, "natsMsg_Destroy") != NULL,
+			"purge destroys outstanding natsMsg* via natsMsg_Destroy");
+		ASSERT(strstr(purge, "->in_use") != NULL,
+			"purge only destroys in-use slots");
+		ASSERT(strstr(purge, "free(row->slots)") != NULL,
+			"purge frees the row's slots buffer");
+		ASSERT(strstr(purge, "row->slots") != NULL &&
+		       strstr(purge, "NULL") != NULL,
+			"purge zeroes the row (slots pointer cleared)");
+		free(purge);
+	}
 
-	ASSERT(strstr(td, "g_msg_refs[ss->handle_idx]") != NULL,
-		"teardown walks the handle's msg-ref row g_msg_refs[ss->handle_idx]");
-	ASSERT(strstr(td, "natsMsg_Destroy") != NULL,
-		"teardown destroys outstanding natsMsg* via natsMsg_Destroy");
-	ASSERT(strstr(td, "->in_use") != NULL,
-		"teardown only destroys in-use slots");
-	ASSERT(strstr(td, "free(row->slots)") != NULL,
-		"teardown frees the row's slots buffer");
-	ASSERT(strstr(td, "row->slots     = NULL") != NULL ||
-	       strstr(td, "row->slots = NULL") != NULL,
-		"teardown zeroes the row (slots pointer cleared)");
-
-	free(td);
+	/* All THREE subscription-destroy sites must invoke the purge helper so
+	 * a later ack of an outstanding natsMsg can never deref a freed sub. */
+	{
+		const char *src = "../nats_consumer_proc.c";
+		const char *sites[] = {
+			"tear_down_retired_subs",   /* retire teardown */
+			"_fetch_batch",             /* vanished/GC'd consumer destroy */
+			"nats_consumer_proc_main",  /* reconnect-epoch sub refresh */
+		};
+		size_t i;
+		for (i = 0; i < sizeof(sites) / sizeof(sites[0]); i++) {
+			char msg[256];
+			char *body = extract_func_body(src, sites[i]);
+			ASSERT(body != NULL, sites[i]);
+			if (body) {
+				snprintf(msg, sizeof(msg),
+					"%s calls purge_msg_ref_row after destroying the sub",
+					sites[i]);
+				ASSERT(strstr(body, "purge_msg_ref_row") != NULL, msg);
+				free(body);
+			}
+		}
+	}
 }
 
 int main(void)

--- a/modules/nats_consumer/tests/test_rpc_reply_pin.c
+++ b/modules/nats_consumer/tests/test_rpc_reply_pin.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 OpenSIPS Solutions
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ *
+ * Regression: the async-RPC reply handler (on_inbox_reply, nats_rpc_consumer.c)
+ * delivered a reply in TWO non-atomic steps: it wrote reply_* and CAS'd the
+ * slot INFLIGHT -> DELIVERED, THEN (separately) re-checked the generation and
+ * rolled back to ABANDONED on a mismatch.  Between the DELIVERED CAS and the
+ * rollback the slot is momentarily DELIVERED with another request's payload; a
+ * worker that has re-claimed the same slot can poll in that window and consume
+ * a reply that belongs to a DIFFERENT request -- a silent wrong-reply delivered
+ * to a SIP transaction.
+ *
+ * Fix: pin the claim first.  CAS INFLIGHT -> DELIVERING, re-validate the
+ * generation (roll back to INFLIGHT on mismatch), THEN write reply_* and store
+ * DELIVERED.  A worker never consumes anything but DELIVERED, and while the slot
+ * is DELIVERING the worker resume never abandons+frees it, so no reclaim (hence
+ * no generation change) can happen under the pin.
+ *
+ * This drives the REAL slot API (../nats_rpc_slot.c under the SHM shim),
+ * -DNATS_RPC_SLOT_COUNT=1 to force slot reuse.  deliver_reply() models
+ * on_inbox_reply; a midpoint hook lets the test run a worker poll at the exact
+ * instant the buggy protocol exposes the reply:
+ *
+ *   -DSIMULATE_PREFIX_BUG -> write+DELIVERED then re-check gen: the reclaiming
+ *                            worker consumes the FOREIGN reply -> assertion FAILS.
+ *   (default)             -> DELIVERING pin + gen re-check before publish: the
+ *                            worker never sees a foreign reply -> ALL PASS.
+ *
+ * Build: TEST_SHIM + ../nats_rpc_slot.c, -DNATS_RPC_SLOT_COUNT=1.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdatomic.h>
+#include <string.h>
+
+#include "../nats_rpc_slot.h"
+
+static int g_fails;
+#define CHECK(cond, label) do { \
+	if (!(cond)) { fprintf(stderr, "FAIL: %s\n", (label)); g_fails++; } \
+	else         { fprintf(stderr, "  ok: %s\n", (label)); } \
+} while (0)
+
+/* We stash the reply's identity (the generation it was minted for) in the
+ * slot's reply_data_len field so a worker poll can read "which reply is this". */
+
+/* Worker poll: returns the reply-id if the slot is DELIVERED, else -1.  A real
+ * worker only ever consumes on DELIVERED (resume_nats_request_slot). */
+static long worker_poll(nats_rpc_slot_t *s)
+{
+	int st = atomic_load_explicit(&s->state, memory_order_acquire);
+	if (st == NATS_RPC_SLOT_DELIVERED)
+		return (long)s->reply_data_len;   /* the delivered reply's id */
+	return -1;
+}
+
+/* Captured: what a re-claiming worker observed at the delivery midpoint. */
+static long        g_mid_observed = -1;
+static nats_rpc_slot_t *g_mid_slot;
+
+static void midpoint_worker_poll(void)
+{
+	g_mid_observed = worker_poll(g_mid_slot);
+}
+
+/*
+ * Model of on_inbox_reply delivering the reply identified by @reply_id, which
+ * was minted for the slot claim of generation @target_gen.  @mid runs at the
+ * point where the buggy protocol has made the reply visible as DELIVERED.
+ */
+static void deliver_reply(nats_rpc_slot_t *s, long reply_id,
+		uint32_t target_gen, void (*mid)(void))
+{
+#ifdef SIMULATE_PREFIX_BUG
+	/* Pre-fix: write + publish DELIVERED, THEN re-check generation. */
+	{
+		int expected = NATS_RPC_SLOT_INFLIGHT;
+		if (atomic_load_explicit(&s->state, memory_order_acquire) != expected)
+			return;
+		s->reply_data_len = (uint32_t)reply_id;             /* write reply */
+		if (!atomic_compare_exchange_strong_explicit(&s->state, &expected,
+				NATS_RPC_SLOT_DELIVERED, memory_order_release,
+				memory_order_relaxed))
+			return;
+		if (mid) mid();                                     /* <-- bug window */
+		if (atomic_load_explicit(&s->generation, memory_order_relaxed)
+				!= target_gen) {
+			int d = NATS_RPC_SLOT_DELIVERED;
+			(void)atomic_compare_exchange_strong_explicit(&s->state, &d,
+				NATS_RPC_SLOT_ABANDONED, memory_order_release,
+				memory_order_relaxed);                      /* too late */
+		}
+	}
+#else
+	/* Fixed: pin -> gen re-check -> write -> DELIVERED. */
+	{
+		int expected = NATS_RPC_SLOT_INFLIGHT;
+		if (!atomic_compare_exchange_strong_explicit(&s->state, &expected,
+				NATS_RPC_SLOT_DELIVERING, memory_order_acq_rel,
+				memory_order_relaxed))
+			return;
+		if (atomic_load_explicit(&s->generation, memory_order_relaxed)
+				!= target_gen) {
+			/* pinned a reclaimed (newer) claim -> undo, drop stale reply */
+			atomic_store_explicit(&s->state, NATS_RPC_SLOT_INFLIGHT,
+				memory_order_release);
+			return;
+		}
+		s->reply_data_len = (uint32_t)reply_id;             /* write reply */
+		if (mid) mid();                                     /* still DELIVERING */
+		atomic_store_explicit(&s->state, NATS_RPC_SLOT_DELIVERED,
+			memory_order_release);
+	}
+#endif
+}
+
+int main(void)
+{
+	nats_rpc_slot_t *sa, *sb;
+	uint32_t gen_a, gen_b;
+
+	CHECK(nats_rpc_slot_init() == 0, "slot pool initialised");
+
+	/* Worker A claims slot S (gen A), publishes. */
+	sa = nats_rpc_slot_claim();
+	CHECK(sa != NULL && nats_rpc_slot_publish(sa) == 0, "A claims + INFLIGHT");
+	gen_a = atomic_load_explicit(&sa->generation, memory_order_relaxed);
+
+	/* A times out -> abandon + free. */
+	(void)nats_rpc_slot_abandon(sa);
+	nats_rpc_slot_free(sa);
+
+	/* Worker B re-claims the SAME slot (gen B = A+1), publishes. */
+	sb = nats_rpc_slot_claim();
+	CHECK(sb == sa, "B re-claims the very same slot (forced reuse)");
+	CHECK(nats_rpc_slot_publish(sb) == 0, "B publishes (INFLIGHT)");
+	gen_b = atomic_load_explicit(&sb->generation, memory_order_relaxed);
+	CHECK(gen_b != gen_a, "generation advanced across the reuse");
+
+	/* A's STALE reply (minted for gen A) now arrives while the slot is B's
+	 * claim.  At the delivery midpoint, worker B polls the slot. */
+	g_mid_slot = sb;
+	g_mid_observed = -1;
+	deliver_reply(sb, /*reply_id=*/(long)gen_a, /*target_gen=*/gen_a,
+		midpoint_worker_poll);
+
+	/* THE CONTRACT: worker B must never consume A's reply. */
+	CHECK(g_mid_observed != (long)gen_a,
+		"worker B never consumes worker A's reply at the delivery midpoint "
+		"(no slot-reuse misdelivery)");
+	/* And B's slot must not be left DELIVERED with a foreign payload. */
+	CHECK(worker_poll(sb) != (long)gen_a,
+		"the slot is not left DELIVERED carrying A's foreign reply");
+
+	nats_rpc_slot_free(sb);
+	nats_rpc_slot_destroy();
+
+	/* ---- production wiring ---------------------------------------- */
+	CHECK(1, "--- source wiring ---");
+	{
+		FILE *f = fopen("../nats_rpc_consumer.c", "r");
+		char line[4096]; int pin = 0, deliv = 0;
+		if (f) {
+			while (fgets(line, sizeof(line), f)) {
+				if (strstr(line, "NATS_RPC_SLOT_DELIVERING")) pin = 1;
+				if (strstr(line, "NATS_RPC_SLOT_DELIVERED"))  deliv = 1;
+			}
+			fclose(f);
+		}
+		CHECK(pin, "on_inbox_reply pins the claim via NATS_RPC_SLOT_DELIVERING");
+		CHECK(deliv, "on_inbox_reply still publishes DELIVERED");
+	}
+
+	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
+		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);
+	return g_fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adversarial correctness/security audit of the NATS modules (`cachedb_nats`, `event_nats`, `nats_consumer`, and their `nats.c` client usage). Defects fixed across three commits; every behavioural change is TDD — a failing test first (its buggy arm reproduces the defect), then the fix. Full `cachedb_nats` (84) and `nats_consumer` unit suites pass; a live KV CRUD e2e passes against a real ≥2.11 JetStream cluster.

## Fixes

### HIGH
- **nats_consumer — use-after-free acking a fetched `natsMsg` after its subscription was destroyed.** The reconnect-epoch refresh and the vanished/GC'd-consumer path destroyed the subscription without purging the process-local msg-ref row, so a later ack dereferenced `msg->sub` on a freed subscription — reachable on any broker reconnect with in-flight messages. Factored the walk into `purge_msg_ref_row()` and call it at all three destroy sites.
- **cachedb_nats — heap OOB in `raw_kv_bucket_info`.** Sized the reply row to a hardcoded 6 columns while the cachedb core frees `expected_kv_no` columns per row → OOB read + bad free when a script requests >6 output vars. Size to `max(expected_kv_no, 6)`.

### MED
- **cachedb_nats — use-after-free read in the counter op** (logged `kvEntry_ValueString()` after `kvEntry_Destroy()`); snapshot the value first.
- **cachedb_nats — embedded-NUL document truncation** on the usrloc merge (`strlen` vs `data_len` → CAS-writes a truncated doc, dropping contacts) and on the generic `*String` write paths (`nats_str_to_buf` now rejects an embedded NUL).
- **event_nats — timer-raised events dropped.** `PROC_TIMER` wasn't NATS-initialised, so usrloc/dialog EXPIRY events published from the timer were dropped and mis-counted as failures. Admit `PROC_TIMER`.
- **cachedb_nats — watcher raised a TTL tombstone (empty-value Put) to EVI as `operation="put"`**; remap to delete to match the index's REMOVE semantics.
- **nats_consumer — async-RPC reply misdelivery under slot reuse.** The reply handler wrote `reply_*` + CAS'd `INFLIGHT→DELIVERED`, then re-checked the generation as a separate step; a worker that re-claimed the slot could consume another request's reply in that window. Added a `DELIVERING` pin state so claim-validation and reply-publish are atomic w.r.t. the worker.

### LOW
- `json`: negative-length guards on the `_lookup`/`_lookup_shard` fv-builders.
- `dbase`: strict counter parse — reject a non-numeric / trailing-garbage / out-of-range value instead of silently resetting the counter to `delta`.
- `watch`: poll the orphan watchdog at the loop top, not only in the `NATS_TIMEOUT` arm (a steady update stream never times out).
- `persist`: sanitize the JSON *key* (not just values) before splicing it into the `key=value;key=value` bind-config, blocking config-field injection from a tampered persist file.
- `sub_config`: fail the consumer build on a NULL required `stream`/`durable` cstr (OOM) rather than handing `nats.c` a NULL Stream.

## Testing
- New: `test_counter_value_uaf`, `test_update_nul_poison`, `test_str_to_buf_nul`, `test_watch_evi_expire_op`, `test_counter_parse_strict`, `test_rpc_reply_pin`. Extended: `test_raw_query_cols`, `test_msg_ref_teardown`, `test_nats_rank`. Each buggy arm reproduces the defect under ASan or a deterministic interleaving.
- Live e2e: `cachedb_nats` KV CRUD (put/get/CAS/stale-CAS/update/delete) green against a 3-node JetStream cluster.

## Deferred (documented follow-ups)
- Watcher `UpdatesOnly` snapshot gap — buffer-and-replay watcher-init restructure (FTS-completeness only; usrloc reads hit KV directly).
- msg-ref generation epoch across handle-index reuse — narrow cross-handle mis-ack window.
- CAS-error / `NATS_ERR` conflation — needs a `nats.c` `jsErrCode` accessor to fix cleanly.
- 64-bit JS sequence in two MI admin commands; `num_documents` stat drift; deriving the orphan-reap TTL from `ack_wait`.
