### PR TITLE
cfgutils: fix async sleep()/usleep() doc examples

### DIFF
--- a/modules/cfgutils/README
+++ b/modules/cfgutils/README
@@ -738,7 +738,7 @@ if(shuffle_avps( $avp(foo) ))
    Example 1.27. async sleep usage
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -759,7 +759,7 @@ route[after_sleep] {
    Example 1.28. async usleep usage
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {

--- a/modules/cfgutils/README.md
+++ b/modules/cfgutils/README.md
@@ -800,7 +800,7 @@ online Manual.
 ```opensips title="async sleep usage"
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -827,7 +827,7 @@ online Manual.
 ```opensips title="async usleep usage"
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {

--- a/modules/cfgutils/doc/cfgutils_admin.xml
+++ b/modules/cfgutils/doc/cfgutils_admin.xml
@@ -908,7 +908,7 @@ if(shuffle_avps( $avp(foo) ))
 		<programlisting format="linespecific">
 {
 ...
-async( sleep("5"), after_sleep );
+async( sleep(5), after_sleep );
 }
 
 route[after_sleep] {
@@ -939,7 +939,7 @@ route[after_sleep] {
 		<programlisting format="linespecific">
 {
 ...
-async( usleep("1000"), after_usleep );
+async( usleep(1000), after_usleep );
 }
 
 route[after_usleep] {


### PR DESCRIPTION
The async `sleep()`/`usleep()` examples in the cfgutils documentation still
use the pre-3.0 string-style parameters:

```
async( sleep("5"), after_sleep );
async( usleep("1000"), after_usleep );
```

Since the typed module interface, both functions (sync and async variants)
declare their parameter as `CMD_PARAM_INT`, so copying these examples into a
config makes OpenSIPS fail at startup:

```
ERROR:core:fix_cmd: Param [1] expected to be an integer or variable
ERROR:core:fix_actions: Failed to fix command <sleep>
ERROR:core:fix_actions: fixing failed (code=-6) at /usr/local/etc/opensips/opensips.cfg:45
ERROR:core:main: failed to initialize routing lists!
```

This updates the examples to use integer parameters, matching the
synchronous `sleep(1);` / `usleep(500000);` examples in the same document.
Both the DocBook source (`doc/cfgutils_admin.xml`) and the generated
`README` are updated.

Verified against master (4.1.0-dev): the quoted form reproduces the error
above; the integer form initializes cleanly.
