### PR TITLE
cachedb_nats: fix orphan test that kills opensips in every container

### DIFF
--- a/modules/cachedb_nats/cachedb_nats.c
+++ b/modules/cachedb_nats/cachedb_nats.c
@@ -57,6 +57,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>  /* getpid() — nats_cdb_parent_pid capture in mod_init */
 
 #include "../../sr_module.h"
 #include "../../globals.h"
@@ -825,6 +826,13 @@ static int init_services(void)
 static int mod_init(void)
 {
 	LM_NOTICE("initializing module cachedb_nats ...\n");
+
+	/* Capture our pid while we are still the MAIN process, pre-fork: the
+	 * dedicated watcher/reaper processes compare getppid() against this to
+	 * detect real re-parenting. Must NOT be inferred as `getppid()==1`,
+	 * because opensips main IS PID 1 under Docker — see
+	 * nats_cdb_parent_gone() in cachedb_nats_watch.c. */
+	nats_cdb_parent_pid = getpid();
 
 	if (init_check_params() < 0 || init_pool() < 0 ||
 	    init_engine() < 0 || init_services() < 0)

--- a/modules/cachedb_nats/cachedb_nats_watch.c
+++ b/modules/cachedb_nats/cachedb_nats_watch.c
@@ -422,8 +422,10 @@ static void watcher_loop(void)
 			 * to PID 1.  The NATS_TIMEOUT arm below also checks this, but a
 			 * broker delivering a steady update stream never times out -- so
 			 * poll here too, rate-limited (every 256 iterations) to keep
-			 * getppid() off the per-event hot path. */
-			if ((++orphan_poll & 0xFF) == 0 && getppid() == 1) {
+			 * getppid() off the per-event hot path.
+			 * NB: compare against the pre-fork pid, not 1 — opensips main
+			 * is PID 1 in a container, see nats_cdb_parent_gone(). */
+			if ((++orphan_poll & 0xFF) == 0 && nats_cdb_parent_gone()) {
 				LM_NOTICE("watcher: parent gone (reparented to init); "
 					"exiting\n");
 				atomic_store(&_watcher_running, 0);
@@ -465,8 +467,10 @@ static void watcher_loop(void)
 				 * version with the bug, prctl rejected, etc.),
 				 * the kernel re-parents us to PID 1.  Detect
 				 * that here and exit so we never become an
-				 * orphan watcher.  Cheap on every 500 ms tick. */
-				if (getppid() == 1) {
+				 * orphan watcher.  Cheap on every 500 ms tick.
+				 * NB: pre-fork pid, not 1 — main is PID 1 in a
+				 * container, see nats_cdb_parent_gone(). */
+				if (nats_cdb_parent_gone()) {
 					LM_NOTICE("watcher: parent gone "
 						"(reparented to init); exiting\n");
 					atomic_store(&_watcher_running, 0);
@@ -659,6 +663,21 @@ static void watcher_loop(void)
  * Returns 0 to proceed, -1 when the caller must exit (parent already
  * dead, or no NATS connection can be established).
  */
+/* Captured by cachedb_nats mod_init() in the MAIN process, before any fork.
+ * 0 until then, which nats_cdb_parent_gone() treats as "cannot tell". */
+pid_t nats_cdb_parent_pid;
+
+int nats_cdb_parent_gone(void)
+{
+	/* Never claim orphanhood we cannot prove: if mod_init did not run in
+	 * this process image (or ran after a fork), stay alive rather than
+	 * take the whole daemon down via SIGCHLD. */
+	if (nats_cdb_parent_pid == 0)
+		return 0;
+
+	return getppid() != nats_cdb_parent_pid;
+}
+
 int nats_cdb_dedicated_proc_guard(const char *who)
 {
 	if (prctl(PR_SET_PDEATHSIG, SIGKILL) == -1) {
@@ -669,12 +688,15 @@ int nats_cdb_dedicated_proc_guard(const char *who)
 
 	/* Race window: the parent could have died between our fork() and
 	 * the prctl() above.  prctl arms only future deaths, so we'd miss
-	 * an already-dead parent and run forever.  Re-check getppid: if
-	 * it's 1 we have already been re-parented to init -- exit now. */
-	if (getppid() == 1) {
+	 * an already-dead parent and run forever.  Re-check the parent --
+	 * against the pid captured pre-fork, NOT against 1: opensips main
+	 * is itself PID 1 under Docker, so `getppid()==1` is true for every
+	 * healthy child there.  See nats_cdb_parent_gone(). */
+	if (nats_cdb_parent_gone()) {
 		LM_NOTICE("%s proc: parent died before we armed "
-			"PR_SET_PDEATHSIG (re-parented to init); exiting\n",
-			who);
+			"PR_SET_PDEATHSIG (re-parented, ppid=%d, expected %d); "
+			"exiting\n", who, (int)getppid(),
+			(int)nats_cdb_parent_pid);
 		return -1;
 	}
 

--- a/modules/cachedb_nats/cachedb_nats_watch.h
+++ b/modules/cachedb_nats/cachedb_nats_watch.h
@@ -21,6 +21,7 @@
 #ifndef CACHEDB_NATS_WATCH_H
 #define CACHEDB_NATS_WATCH_H
 
+#include <sys/types.h>  /* pid_t — nats_cdb_parent_pid */
 #include <nats/nats.h>
 
 /*
@@ -80,6 +81,33 @@ void nats_watcher_proc_main(int rank);
  * never call it from SIP workers or the MI process.
  */
 int nats_cdb_dedicated_proc_guard(const char *who);
+
+/**
+ * Expected parent pid of the dedicated processes, captured by mod_init()
+ * in the MAIN process before any fork.  Used by nats_cdb_parent_gone().
+ */
+extern pid_t nats_cdb_parent_pid;
+
+/**
+ * Orphan test for the dedicated processes (watcher / reaper).
+ *
+ * ⚠️ Do NOT use `getppid() == 1` for this. That is only a valid orphan
+ * test when init is a DIFFERENT process from our parent. Under Docker —
+ * i.e. every Saturn deployment — opensips main runs as PID 1, so a
+ * freshly forked child's legitimate getppid() IS 1. The old heuristic
+ * therefore fired instantly on startup: the reaper logged "parent died
+ * before we armed PR_SET_PDEATHSIG" and exited, and core:handle_sigs
+ * tore down the whole daemon on the resulting SIGCHLD ("terminating due
+ * to SIGCHLD") — a ~60s crash loop with exit status 0 and no error.
+ *
+ * Comparing against the pid captured pre-fork is correct both inside and
+ * outside a container.
+ *
+ * @return 1 when we have really been re-parented, 0 while the original
+ *         parent is still our parent (or the pid was never captured, in
+ *         which case we deliberately do NOT claim orphanhood).
+ */
+int nats_cdb_parent_gone(void);
 
 /**
  * [P2.7] Periodic FTS index resync pass body: acquires a fresh KV

--- a/modules/cachedb_nats/tests/test_dedicated_watcher_proc.c
+++ b/modules/cachedb_nats/tests/test_dedicated_watcher_proc.c
@@ -124,9 +124,23 @@ int main(void)
 		"PR_SET_PDEATHSIG, SIGKILL"),
 		"watcher arms PR_SET_PDEATHSIG with SIGKILL (uncatchable)");
 	ASSERT(file_contains("../cachedb_nats_watch.c",
-		"getppid() == 1"),
-		"watcher polls getppid in loop as belt-and-suspenders "
+		"nats_cdb_parent_gone()"),
+		"watcher polls the parent in loop as belt-and-suspenders "
 		"backstop for the rare case where PDEATHSIG didn't arm");
+
+	/* REGRESSION LOCK (2026-08-05). `getppid() == 1` is NOT a valid orphan
+	 * test: it is only meaningful when init is a DIFFERENT process from our
+	 * parent. Under Docker — every Saturn deployment — opensips main runs as
+	 * PID 1, so a freshly forked child's legitimate getppid() IS 1. The old
+	 * heuristic fired instantly at startup: the reaper logged "parent died
+	 * before we armed PR_SET_PDEATHSIG" and exited, and core:handle_sigs
+	 * tore the whole daemon down on the resulting SIGCHLD ("terminating due
+	 * to SIGCHLD") — a ~60s crash loop, exit status 0, no error logged.
+	 * nats_cdb_parent_gone() compares against the pid captured pre-fork in
+	 * mod_init, which is correct inside and outside a container. */
+	ASSERT(!file_contains("../cachedb_nats_watch.c", "getppid() == 1"),
+		"no bare getppid()==1 orphan test (false-fires when opensips "
+		"main is PID 1, i.e. in every container)");
 
 	fprintf(stderr, "\n=== %s (fails=%d) ===\n",
 		g_fails == 0 ? "ALL PASS" : "FAILURES", g_fails);


### PR DESCRIPTION
The dedicated watcher/reaper processes detect orphaning with `getppid() == 1`. That is only a valid test when init is a **different** process from our parent. Under Docker — and opensips is overwhelmingly run in containers — **opensips main runs as PID 1**, so a freshly forked child`s legitimate `getppid()` IS 1 and the test fires immediately at startup.

## Observed

opensips 4.1.0-dev in a container, ~150 processes, `cachedb_nats` loaded with the reaper enabled:

```
cachedb_nats:nats_cdb_reaper_proc_main: NATS reaper proc starting (pid=39, ppid=1): reap every 30 s
cachedb_nats:nats_cdb_dedicated_proc_guard: reaper proc: parent died before we armed
                                            PR_SET_PDEATHSIG (re-parented to init); exiting
core:handle_sigs: child process 39 exited normally, status=0
core:handle_sigs: terminating due to SIGCHLD
```

opensips treats any child exit as fatal, so the whole daemon shuts down gracefully and the container restarts — a ~60-70 s crash loop with **exit status 0, a clean module-destroy sequence, and not one error line**, which makes it look like an external `docker stop` rather than a module bug. Note the reaper prints `ppid=1` as normal one line before the guard treats that same value as proof of death.

## Fix

Capture the main pid in `mod_init()` (main process, pre-fork) and compare `getppid()` against it. Correct inside and outside a container, and strictly more precise than the `==1` heuristic — it also detects re-parenting to a non-init subreaper or PID-namespace init.

All three sites are converted, not only the one that fired:

* `cachedb_nats_watch.c` — `nats_cdb_dedicated_proc_guard()` (reaper + watcher entry)
* `cachedb_nats_watch.c` — watcher event loop, polled every 256 events
* `cachedb_nats_watch.c` — watcher 500 ms `NATS_TIMEOUT` tick

Leaving the latter two would let the watcher die later for the same reason. Verified no other `getppid() == 1` remains in the tree.

`nats_cdb_parent_gone()` returns 0 when the pid was never captured, so it can never claim orphanhood it cannot prove — failing closed here means staying alive, because a false positive takes down the entire daemon.

## Test

`tests/test_dedicated_watcher_proc.c` asserted the source contained the literal `"getppid() == 1"`, so it encoded the bug. It now asserts `nats_cdb_parent_gone()` is used **and** that the bare literal is absent, as a regression lock.

## Verification

Deployed to a containerised proxy. Before: reaper exited at startup, daemon cycled every ~69 s. After:

```
[39] NATS reaper proc starting (pid=39, ppid=1)
PID 39  PPID 1  ELAPSED 03:02      (main pid 1 ELAPSED 03:07)
```

The reaper survives the full daemon lifetime; `parent died before we armed` count is 0, and the restart cycle is gone (verified flat `RestartCount`/`StartedAt` across ~7 minutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)