### PR TITLE
cachedb_nats: drop internal spec references from user-facing log messages

### DIFF
--- a/modules/cachedb_nats/cachedb_nats.c
+++ b/modules/cachedb_nats/cachedb_nats.c
@@ -563,7 +563,7 @@ static int init_check_params(void)
 	if (cdbn_kv_ttl_guard(kv_ttl) != 0) {
 		LM_ERR("cachedb_nats: kv_ttl=%d invalid -- a non-zero kv_ttl sets the "
 		       "KV bucket MaxAge, which overrides per-message TTL and would "
-		       "EXPIRE PERMANENT CONTACTS (expires==0). Set kv_ttl=0 [REV-7].\n",
+		       "EXPIRE PERMANENT CONTACTS (expires==0). Set kv_ttl=0.\n",
 		       kv_ttl);
 		return -1;
 	}
@@ -666,14 +666,13 @@ static int init_pool(void)
 				LM_ERR("cachedb_nats: connection URL '%s' is INSECURE "
 					"for a PII/lawful-intercept store and "
 					"require_secure_url=1 -- refusing to start. Use "
-					"tls:// with an authenticated account (SPEC \xc2\xa7""11 "
-					"[REV-24])\n", _redacted_url);
+					"tls:// with an authenticated account.\n", _redacted_url);
 				return -1;
 			}
 			LM_WARN("cachedb_nats: connection URL '%s' is INSECURE for a "
 				"PII/lawful-intercept store (subscriber IP, user-agent, "
 				"call-id, path) — use tls:// with an authenticated account "
-				"and one bucket per trust domain (SPEC \xc2\xa7""11 [REV-24])\n",
+				"and one bucket per trust domain.\n",
 				_redacted_url);
 		}
 
@@ -890,14 +889,14 @@ static int child_init(int rank)
 					"require_usrloc_safe_bucket=1 -- refusing to start "
 					"(it would SILENTLY EXPIRE permanent contacts). "
 					"Recreate the bucket with MaxAge=0 (kv_ttl=0) and "
-					"migrate [REV-25].\n",
+					"migrate.\n",
 					kv_bucket, (long long)maxage_ns);
 				return -1;
 			}
 			LM_WARN("cachedb_nats: bound bucket '%s' has a non-zero backing-stream "
 				"MaxAge (%lld ns) -- it will SILENTLY EXPIRE ALL keys including "
 				"PERMANENT contacts (expires==0). If this bucket backs usrloc, "
-				"recreate it with MaxAge=0 (kv_ttl=0) and migrate [REV-25].\n",
+				"recreate it with MaxAge=0 (kv_ttl=0) and migrate.\n",
 				kv_bucket, (long long)maxage_ns);
 		}
 		/* Reaper-only expiry (P1.5): a history-keeping bucket is fine

--- a/modules/cachedb_nats/cachedb_nats_json.c
+++ b/modules/cachedb_nats/cachedb_nats_json.c
@@ -571,7 +571,7 @@ static int merge_subkey_cb(const char *kfield, int kflen,
 			/* [REV-8] stale cseq: keep the existing
 			 * higher-cseq value, discard the incoming one
 			 * (no rollback). */
-			LM_DBG("[REV-8] discarded stale-cseq write; "
+			LM_DBG("discarded stale-cseq write; "
 				"kept the existing higher-cseq contact\n");
 			if (cdbn_sink_write(s, kvstart,
 					(int)(kvend - kvstart)) < 0)

--- a/modules/cachedb_nats/cachedb_nats_json_rowmeta.c
+++ b/modules/cachedb_nats/cachedb_nats_json_rowmeta.c
@@ -521,7 +521,7 @@ void cdbn_row_patch_last_mod_int64(const char *json, int len, cdb_dict_t *row_di
 					fp->val.type = CDB_INT64;
 					fp->val.val.i64 = lm;
 					if (lm > (int64_t)INT32_MAX)  /* observe the preserved int64 from the production READ (not `nats kv`) — the int32-clamp case */
-						LM_DBG("[REV-30] preserved post-2038 last_mod=%lld\n", (long long)lm);
+						LM_DBG("preserved post-2038 last_mod=%lld\n", (long long)lm);
 					break;
 				}
 			}


### PR DESCRIPTION
Seven `LM_ERR` / `LM_WARN` / `LM_DBG` messages cite internal document references that an operator reading the log cannot resolve:

| reference | occurrences |
|---|---|
| `SPEC §11 [REV-24]` | 2 |
| `[REV-25]` | 2 |
| `[REV-7]`, `[REV-8]`, `[REV-30]` | 1 each |

These are not RFCs and not anything published on nats.io, so they add noise to operator-visible output without giving the reader an action they can take or a document they can look up.

Each message keeps its full actionable content; only the dangling reference is removed:

```
before:  cachedb_nats: connection URL ... is INSECURE for a PII/lawful-intercept
         store (subscriber IP, user-agent, call-id, path) — use tls:// with an
         authenticated account and one bucket per trust domain (SPEC §11 [REV-24])

after:   cachedb_nats: connection URL ... is INSECURE for a PII/lawful-intercept
         store (subscriber IP, user-agent, call-id, path) — use tls:// with an
         authenticated account and one bucket per trust domain.
```

The warning itself is unchanged in substance and still fires: it is accurate, it is redacted via `nats_redact_url()` before logging, and it remains paired with the `require_secure_url=1` hard-failure path.

Removing the `SPEC "\xc2\xa7""11` form also drops the adjacent string-splitting workaround, which existed only to prevent the compiler from reading `\xc2\xa711` as a single longer hex escape.

Code comments referencing the same internal revisions are deliberately left untouched — those are for developers working in the tree, not for operators reading logs.

Files: `cachedb_nats.c` (5), `cachedb_nats_json.c` (1), `cachedb_nats_json_rowmeta.c` (1). No functional change.