### PR TITLE
presence,pua: do not call xmlCleanupParser() per operation (SIGSEGV)

### DIFF
--- a/modules/presence/notify.c
+++ b/modules/presence/notify.c
@@ -2434,7 +2434,6 @@ str* create_winfo_xml(watcher_t* watchers, char* version,
 
 	xmlFreeDoc(doc);
 
-	xmlCleanupParser();
 
     return body;
 

--- a/modules/presence/presentity.c
+++ b/modules/presence/presentity.c
@@ -350,7 +350,6 @@ int get_dialog_state(str body, int *dialog_state)
 	}
 	xmlFree(state);
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 
 	if(i == DLG_STATES_NO)
 	{
@@ -1608,7 +1607,6 @@ str* xml_dialog_gen_presence(str* pres_uri, int dlg_state)
 error:
 	if(pres_doc)
 		xmlFreeDoc(pres_doc);
-	xmlCleanupParser();
 
 	return dialog_body;
 }
@@ -1652,7 +1650,6 @@ str* xml_dialog2presence(str* pres_uri, str* body)
 	}
 	xmlFree(state);
 	xmlFreeDoc(dlg_doc);
-	xmlCleanupParser();
 
 	if(i == DLG_STATES_NO)
 	{
@@ -1748,7 +1745,6 @@ str* build_offline_presence(str* pres_uri)
 error:
 	if(pres_doc)
 		xmlFreeDoc(pres_doc);
-	xmlCleanupParser();
 
 	return body;
 }

--- a/modules/presence_dialoginfo/notify_body.c
+++ b/modules/presence_dialoginfo/notify_body.c
@@ -98,7 +98,6 @@ str* dlginfo_agg_nbody(str* pres_user, str* pres_domain, str** body_array, int n
 		LM_ERR("while aggregating body\n");
 	}
 
-	xmlCleanupParser();
 
 	if (n_body== NULL)
 		n_body = _build_empty_dialoginfo(pres_uri_char, NULL);
@@ -272,7 +271,6 @@ str* agregate_xmls(str* pres_user, str* pres_domain, str** body_array, int n, in
 	if(xml_array!=NULL)
 		pkg_free(xml_array);
 
-	xmlCleanupParser();
 
 	return body;
 
@@ -422,7 +420,6 @@ str* build_dialoginfo(str* pres_user, str* pres_domain)
 	LM_DBG("new_body:\n%.*s\n",body->len, body->s);
 	/*free the document */
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 	return body;
 error:
 	if(doc)
@@ -468,7 +465,6 @@ static str* _build_empty_dialoginfo(const char* pres_uri_char, str* extra_hdrs)
 		&nbody->len);
 
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 
 	return nbody;
 error:

--- a/modules/presence_reginfo/notify_body.c
+++ b/modules/presence_reginfo/notify_body.c
@@ -68,7 +68,6 @@ str *reginfo_agg_nbody(str *pres_user, str *pres_domain, str **body_array,
 		LM_ERR("while aggregating body\n");
 	}
 
-	xmlCleanupParser();
 
 	return n_body;
 }
@@ -204,7 +203,6 @@ str *aggregate_xmls(str *pres_user, str *pres_domain, str **body_array, int n)
 	if(xml_array)
 		pkg_free(xml_array);
 
-	xmlCleanupParser();
 
 	return body;
 

--- a/modules/presence_xml/add_events.c
+++ b/modules/presence_xml/add_events.c
@@ -71,12 +71,10 @@ int	xml_publ_handl(struct sip_msg* msg, int* sent_reply)
 		goto error;
 	}
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 	return 1;
 
 error:
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 	return -1;
 
 }
@@ -122,13 +120,11 @@ str* bla_set_version(subs_t* subs, str* body)
 
 	xmlFreeDoc(doc);
 
-	xmlCleanupParser();
 	return new_body;
 
 error:
 	if(doc)
 		xmlFreeDoc(doc);
-	xmlCleanupParser();
 	return 0;
 }
 

--- a/modules/pua/add_events.c
+++ b/modules/pua/add_events.c
@@ -159,7 +159,6 @@ int pres_process_body(publ_info_t* publ, str** fin_body, int ver, str* tuple)
 	doc= NULL;
 
 	*fin_body= body;
-	xmlCleanupParser();
 	return 1;
 
 error:

--- a/modules/pua_dialoginfo/dialog_publish.c
+++ b/modules/pua_dialoginfo/dialog_publish.c
@@ -264,7 +264,6 @@ static str* build_dialoginfo(str *callid, char *d_id, char *state,
 
     /*free the document */
 	xmlFreeDoc(doc);
-    xmlCleanupParser();
 
 	return body;
 

--- a/modules/pua_dialoginfo/pua_dialoginfo.c
+++ b/modules/pua_dialoginfo/pua_dialoginfo.c
@@ -690,7 +690,6 @@ int dialoginfo_process_body(struct publ_info* publ, str** fin_body,
 	if (*fin_body == NULL)
 		LM_DBG("NULL fin_body\n");
 
-	xmlCleanupParser();
 	return 1;
 
 	error:
@@ -698,7 +697,6 @@ int dialoginfo_process_body(struct publ_info* publ, str** fin_body,
 		xmlFreeDoc(doc);
 	if (body)
 		pkg_free(body);
-	xmlCleanupParser();
 	return -1;
 }
 

--- a/modules/pua_reginfo/usrloc_cb.c
+++ b/modules/pua_reginfo/usrloc_cb.c
@@ -264,7 +264,6 @@ str *build_reginfo_full(urecord_t *record, ucontact_t *contact, str aor[], unsig
 
 	/*free the document */
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 
 	return body;
 error:

--- a/modules/pua_usrloc/ul_publish.c
+++ b/modules/pua_usrloc/ul_publish.c
@@ -178,7 +178,6 @@ str* build_pidf(ucontact_t* c)
 
     /*free the document */
 	xmlFreeDoc(doc);
-    xmlCleanupParser();
 
 	return body;
 

--- a/modules/pua_xmpp/simple2xmpp.c
+++ b/modules/pua_xmpp/simple2xmpp.c
@@ -490,7 +490,6 @@ done:
 	}
 
 	xmlBufferFree(buffer);
-	xmlCleanupParser();
 
 	if(sip_doc)
 		xmlFreeDoc(sip_doc);
@@ -507,7 +506,6 @@ error:
 		xmlFree(note);
 	if(buffer)
 		xmlBufferFree(buffer);
-	xmlCleanupParser();
 
 	return -1;
 
@@ -634,7 +632,6 @@ int winfo2xmpp(str* to_uri, str* body, str* id)
 	}
 
 	xmlFreeDoc(notify_doc);
-	xmlCleanupParser();
 	return 0;
 
 error:
@@ -647,7 +644,6 @@ error:
 		xmlFree(watcher);
 	if(buffer)
 		xmlBufferFree(buffer);
-	xmlCleanupParser();
 
 	return -1;
 }

--- a/modules/pua_xmpp/xmpp2simple.c
+++ b/modules/pua_xmpp/xmpp2simple.c
@@ -126,14 +126,12 @@ void pres_Xmpp2Sip(char *msg, int type, void *param)
 	//		send_reply_message(pres_node);
 
 	xmlFreeDoc(doc);
-	xmlCleanupParser();
 	return ;
 
 error:
 
 	if(doc)
 		xmlFreeDoc(doc);
-	xmlCleanupParser();
 
 	return ;
 }


### PR DESCRIPTION
> Same fix as #8, targeted at `feature/nats`. That branch is heavily diverged from `master`, so it will not inherit the fix, and it is the branch these builds are cut from — it carries all 27 affected call sites today.

## Summary

`xmlCleanupParser()` frees libxml2 **process-global** state. libxml2 documents that it must be called only once the process has finished using the library, and warns explicitly:

> One should call `xmlCleanupParser()` only when the process has finished using the library and all XML/HTML documents built with it. **WARNING: if your application is multithreaded or has plugin support, calling this may crash the application if another thread or a plugin is still using libxml2.**

OpenSIPS is a plugin architecture, and several independently loaded modules (`presence*`, `pua*`) use libxml2 in the same process. Any module calling `xmlCleanupParser()` at the end of an operation destroys global state that other modules — and later invocations of the same function — still rely on.

## Symptom

SIGSEGV inside libxml2 on the **second** XML build in a process. Because the core terminates on `SIGCHLD` when a worker dies, one worker crash takes the whole daemon down, producing a restart loop:

```
CRITICAL:core:sig_usr: segfault in process pid: N, id: M
INFO:core:handle_sigs: child process N exited by a signal 11
INFO:core:handle_sigs: terminating due to SIGCHLD
```

## Backtrace

Observed in `pua_usrloc`, which ends `build_pidf()` with `xmlCleanupParser()` (`ul_publish.c:181`):

```
#0  xmlBufFree            libxml2
#1  xmlStringGetNodeList  libxml2
#2  xmlNewDocNode         libxml2
#3  xmlNewChild           libxml2
#4  build_pidf            modules/pua_usrloc/ul_publish.c:158
#5  ul_contact_publish    modules/pua_usrloc/ul_publish.c:228   (type=UL_CONTACT_UPDATE)
#6  run_ul_callbacks      modules/usrloc/ul_callback.h:128
#7  update_ucontact       modules/usrloc/ucontact.c:1005
...
#11 save                  modules/registrar/save.c:745
```

Two details make this unambiguous.

**1. The crashing statement passes only compile-time constants:**

```c
basic_node = xmlNewChild(status_node, NULL, BAD_CAST "basic", BAD_CAST "open");
```

**2. The document and nodes are valid at the crash:**

```
doc         = {type = XML_DOCUMENT_NODE, version = "1.0", dict = 0x0, children = <root_node>}
status_node = {type = XML_ELEMENT_NODE, name = "status", parent = <tuple_node>}
```

So neither malformed input nor a corrupt document — libxml2 own globals had already been freed by the previous call.

It also explains why only *some* calls fail: `xmlNewDoc()`, `xmlNewNode()`, `xmlNewProp()` and `xmlNewChild()` with `NULL` content all succeed, because they never touch the freed subsystem. The first call passing **content** enters `xmlStringGetNodeList()`, which uses the buffer subsystem, and dies in `xmlBufFree()`.

## Reproducing

General shape: **two libxml2 document builds in one process, where the first ends with `xmlCleanupParser()`.**

```
loadmodule "presence.so"
loadmodule "pua.so"
loadmodule "pua_usrloc.so"
modparam("pua_usrloc", "default_domain", "example.com")
modparam("pua_usrloc", "presence_server", "sip:presence@example.com:5060")
```

with `save("location")` in the request route.

1. Start the proxy.
2. Cause **two or more** `pua_usrloc` publishes in the same worker — either register a UAC and re-register, or start with two or more contacts already in `location` so usrloc restores and publishes for each.
3. The first publish succeeds and calls `xmlCleanupParser()`; the second segfaults in `xmlNewChild()`.

The second form is the more reliable trigger since it needs no SIP traffic at all — the daemon crash-loops from startup once more than one contact is restored.

Any other module pair works too, e.g. a `presence` NOTIFY (which calls `xmlCleanupParser()` in `notify.c`) followed by any `pua*` publish in the same process.

## Verification

Built and deployed with this change applied. Before: the daemon crash-looped, reaching 27 restarts with a core dump per crash. After: the proxy starts clean and stays up, with `cachedb_nats` and the rest of the module set initialising normally.

## The fix

Remove all 27 calls across 12 files. Every one was a standalone statement following `xmlFreeDoc()` / `xmlBufferFree()` / `pkg_free()`; none was the body of a brace-less `if`/`else`, so there are no control-flow changes — verified against the diff.

Not calling the function leaves libxml2 global caches allocated until process exit, which is the documented, supported behaviour for a long-running process.

Affected: `presence`, `presence_xml`, `presence_dialoginfo`, `presence_reginfo`, `pua`, `pua_usrloc`, `pua_dialoginfo`, `pua_reginfo`, `pua_xmpp`.