### PR TITLE
ci: run the opensips.org docs publication only in the canonical repo

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -36,6 +36,9 @@ concurrency:
 jobs:
   changed-components:
     name: Find changed documentation components
+    # The dispatch job needs the OpenSIPS web GitHub App secrets, which
+    # only exist in the canonical repository -- skip on forks.
+    if: github.repository == 'OpenSIPS/opensips'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.components.outputs.matrix }}


### PR DESCRIPTION
The `Publish opensips.org documentation` workflow authenticates with the OpenSIPS web GitHub App (`OPENSIPS_WEB_APP`/`KEY`/`REPO` secrets), which only exist in `OpenSIPS/opensips`. On this fork every docs-touching push fails with `The 'client-id' input must be set` (red X on every merge from master, including `e0d81ac9a1`).

Guard the first job on `github.repository == 'OpenSIPS/opensips'`; the `dispatch` job is `needs`-dependent and skips automatically. Upstreamable as-is if ever wanted.