### PR TITLE
ci: run the Coverity scan only in the canonical repo

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,10 @@ env:
 
 jobs:
   coverity:
-    if: github.ref == 'refs/heads/master'
+    # Needs COVERITY_SCAN_TOKEN, which only exists in the canonical
+    # repository -- the schedule fires on forks too, so guard on the
+    # repository as well as the branch.
+    if: github.repository == 'OpenSIPS/opensips' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Reworked after the 4.x-head merge (`e95b89e839`): master replaced `sync-coverity.yml` with `coverity.yml`, which has the same fork defect — the weekly schedule fires on the fork's master, passes the existing branch-only guard, and fails on the missing `COVERITY_SCAN_TOKEN`/`COVERITY_EMAIL` secrets.

Add `github.repository == 'OpenSIPS/opensips'` to the job guard so forks skip it.