### PR TITLE
ci: build the CI images only in the canonical repo

### DIFF
--- a/.github/workflows/build-ci-images.yml
+++ b/.github/workflows/build-ci-images.yml
@@ -14,7 +14,9 @@ on:
 
 jobs:
   build:
-    if: github.ref == 'refs/heads/master'
+    # The images are pushed to ghcr.io/opensips, which forks cannot
+    # write to (the schedule fires there too) -- canonical repo only.
+    if: github.repository == 'OpenSIPS/opensips' && github.ref == 'refs/heads/master'
     name: Ubuntu ${{ matrix.os }} CI image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
The `Build CI images` job pushes to `ghcr.io/opensips/ubuntu-ci`, which forks cannot write to. The existing `github.ref == 'refs/heads/master'` guard does not help: the weekly schedule fires on the fork's master and dies with `permission_denied: The requested installation does not exist` (failures on 08-09 and 08-16).

Add `github.repository == 'OpenSIPS/opensips'` to the job guard so forks skip it.