### PR TITLE
ci: run the opensips.org docs publication only in the canonical repo (master)

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -36,6 +36,9 @@ concurrency:
 jobs:
   changed-components:
     name: Find changed documentation components
+    # The dispatch job needs the OpenSIPS web GitHub App secrets, which
+    # only exist in the canonical repository -- skip on forks.
+    if: github.repository == 'OpenSIPS/opensips'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.components.outputs.matrix }}


### PR DESCRIPTION
Master counterpart of #11. The workflow authenticates with the OpenSIPS web GitHub App secrets, which only exist in `OpenSIPS/opensips`; on this fork every docs-touching push to master fails with `The 'client-id' input must be set` (most recently on today's upstream sync).

Guard the first job on `github.repository == 'OpenSIPS/opensips'`; the `dispatch` job is `needs`-dependent and skips automatically.