### PR TITLE
ci: run the Coverity scan only in the canonical repo (master)

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -18,7 +18,10 @@ env:
 
 jobs:
   coverity:
-    if: github.ref == 'refs/heads/master'
+    # Needs COVERITY_SCAN_TOKEN, which only exists in the canonical
+    # repository -- the schedule fires on forks too, so guard on the
+    # repository as well as the branch.
+    if: github.repository == 'OpenSIPS/opensips' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
Master counterpart of #12. The `coverity` job needs `COVERITY_SCAN_TOKEN`/`COVERITY_EMAIL`, which only exist in `OpenSIPS/opensips`. The weekly schedule fires on the fork's master, passes the existing branch-only guard, and fails on the missing secrets (predecessor `sync-coverity.yml` failed the last two Sundays the same way).

Add `github.repository == 'OpenSIPS/opensips'` to the job guard.