### PR TITLE
nats_consumer: fix the compose harness against the pinned libnats

### DIFF
--- a/modules/nats_consumer/tests/Dockerfile
+++ b/modules/nats_consumer/tests/Dockerfile
@@ -16,9 +16,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         bison \
         flex \
         pkg-config \
+        cmake \
+        wget \
         libssl-dev \
         libcurl4-openssl-dev \
-        libnats-dev \
         libpcre2-dev \
         libxml2-dev \
         libncurses-dev \
@@ -26,6 +27,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         netbase \
         git \
     && rm -rf /var/lib/apt/lists/*
+
+# trixie's libnats-dev (3.10) predates the per-key KV TTL surface
+# lib/nats requires (kvStore_CreateWithTTL etc.) -- build the same
+# pinned nats.c every CI leg uses.  Copied alone first so tree edits
+# don't invalidate this layer.
+COPY scripts/build/install_libnats.sh /tmp/install_libnats.sh
+RUN sh /tmp/install_libnats.sh
 
 WORKDIR /src
 COPY . /src
@@ -52,7 +60,6 @@ FROM debian:trixie-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libssl3 \
         libcurl4 \
-        libnats3.10 \
         libpcre2-8-0 \
         libxml2 \
         ca-certificates \
@@ -62,12 +69,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
+# The pinned libnats built in the builder stage, not trixie's 3.10 --
+# lib/nats dlopens it at runtime and resolves the KV TTL symbols.
+COPY --from=builder /usr/local/lib/libnats.so*    /usr/local/lib/
 COPY --from=builder /usr/local/sbin/opensips      /usr/local/sbin/opensips
 COPY --from=builder /usr/local/lib64/opensips/    /usr/local/lib64/opensips/
 COPY modules/nats_consumer/tests/opensips.cfg   /etc/opensips/opensips.cfg
 COPY modules/nats_consumer/tests/run.sh         /usr/local/bin/run.sh
 
-RUN chmod +x /usr/local/bin/run.sh && \
+RUN ldconfig && \
+    chmod +x /usr/local/bin/run.sh && \
     mkdir -p /var/run/opensips /var/lib/opensips/nats_consumer
 
 EXPOSE 5060/udp

--- a/modules/nats_consumer/tests/docker-compose.yaml
+++ b/modules/nats_consumer/tests/docker-compose.yaml
@@ -45,12 +45,11 @@ services:
         condition: service_healthy
     environment:
       - NATS_URL=nats://nats:4222
-      # The runtime stage installs libnats3.10 but not libnats-dev, so
-      # the bare "libnats.so" SONAME the default search uses isn't on
-      # disk -- only the major-suffixed "libnats.so.3.10".  Point
-      # nats_dl_load() at that explicit SONAME so the dlopen succeeds
-      # without needing the dev package in the runtime image.
-      - NATS_DL_LIBNATS_PATH=libnats.so.3.10
+      # The runtime stage carries the pinned libnats build at
+      # /usr/local/lib (no distro package, no dev symlink in the ld
+      # cache).  An explicit path makes nats_dl_load()'s dlopen bypass
+      # the SONAME search entirely and stays valid across pin bumps.
+      - NATS_DL_LIBNATS_PATH=/usr/local/lib/libnats.so
     ports:
       - "15060:5060/udp"
     volumes:


### PR DESCRIPTION
Found while regression-testing the 4.x-head merge (`e95b89e839`): `modules/nats_consumer/tests/run_all.sh` could not even build its docker image — trixie's `libnats-dev` (3.10) predates `kvStore_CreateWithTTL`, which `lib/nats`'s dl table now requires, and after fixing that, every compose-stack case still failed because `NATS_DL_LIBNATS_PATH` pinned the now-absent distro SONAME `libnats.so.3.10`.

- builder stage now runs `scripts/build/install_libnats.sh` (the same pinned nats.c `47da1620` every CI leg uses) instead of installing `libnats-dev`
- runtime stage ships the built `libnats.so` instead of `libnats3.10`
- compose sets `NATS_DL_LIBNATS_PATH=/usr/local/lib/libnats.so` — an explicit path dlopen, immune to ld-cache SONAME semantics and pin bumps

Verified: `run_all.sh` on the merged tree now reports `e2e summary: pass=15 fail=0 skip=1` (the skip is the documented tls_mgm-not-built case). Note for local runs: the box's nftables forward chain drops docker bridge traffic when `br_netfilter` is loaded with `bridge-nf-call-iptables=1`; `/etc/sysctl.d/99-gh3902-sipssert.conf` already pins it to 0 but only applies when the module is loaded at boot.