### PR TITLE
cachedb_nats: drop the dead enable_search_index modparam from the outage test

### DIFF
--- a/modules/cachedb_nats/tests/test_outage_matrix_e2e.sh
+++ b/modules/cachedb_nats/tests/test_outage_matrix_e2e.sh
@@ -90,7 +90,6 @@ modparam("cachedb_nats", "nats_url", "${PRIV_URL}")
 modparam("cachedb_nats", "cachedb_url", "nats:loc://127.0.0.1:${PORT}/")
 modparam("cachedb_nats", "kv_bucket", "${BUCKET}")
 modparam("cachedb_nats", "kv_replicas", 1)
-modparam("cachedb_nats", "enable_search_index", 1)
 modparam("cachedb_nats", "kv_watch", ">")
 # keep op timeouts small so even a non-fast-fail path can't stall long
 modparam("cachedb_nats", "kv_op_timeout_ms", 800)


### PR DESCRIPTION
Found while regression-testing `e95b89e839`: `test_outage_matrix_e2e.sh` still sets `modparam("cachedb_nats", "enable_search_index", 1)`, which the P1.2 FTS split removed (loading `cachedb_nats_fts.so` is the enable now). The generated cfg fails to parse, so the test dies before its first check. No batch runs these host-side cachedb_nats shell tests, which is why the rot went unnoticed.

The outage matrix doesn't exercise the search index — delete the line. Verified locally: `PASS: outage matrix: 28 checks green (up=ok, SIGKILL=clean+fast fail, restart=recovered, watcher resumed)`, plus `test_kv_crud_e2e.sh` and `test_kv_watch_basic.sh` both PASS on the same tree.